### PR TITLE
only add DLL directory if SCIPOPTDIR exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - consistent handling of filenames for reading/writing
+- fix error when no SCIPOPTDIR env var is set on Windows
 
 ## 3.0.4 - 2020-10-30
 ### Added

--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -3,7 +3,8 @@ __version__ = '3.0.4'
 # required for Python 3.8 on Windows
 import os
 if hasattr(os, 'add_dll_directory'):
-    os.add_dll_directory(os.path.join(os.getenv('SCIPOPTDIR').strip('"'), 'bin'))
+    if os.getenv('SCIPOPTDIR'):
+        os.add_dll_directory(os.path.join(os.getenv('SCIPOPTDIR').strip('"'), 'bin'))
 
 # export user-relevant objects:
 from pyscipopt.Multidict import multidict


### PR DESCRIPTION
This prevents an error when there is no SCIPOPTDIR env variable on Windows and the __init__ still tries to append the SCIPOPTDIR path to the DLL dir list.