### PR TITLE
fix: use_cython bool different from imported function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if "--debug" in sys.argv:
     extra_compile_args.append('-UNDEBUG')
     sys.argv.remove("--debug")
 
-cythonize = True
+use_cython = True
 
 packagedir = os.path.join('src', 'pyscipopt')
 
@@ -55,12 +55,12 @@ except ImportError:
     if not os.path.exists(os.path.join(packagedir, 'scip.c')):
         print('Cython is required')
         quit(1)
-    cythonize = False
+    use_cython = False
 
 if not os.path.exists(os.path.join(packagedir, 'scip.pyx')):
-    cythonize = False
+    use_cython = False
 
-ext = '.pyx' if cythonize else '.c'
+ext = '.pyx' if use_cython else '.c'
 
 extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)],
                           include_dirs=[includedir],
@@ -70,33 +70,32 @@ extensions = [Extension('pyscipopt.scip', [os.path.join(packagedir, 'scip'+ext)]
                           extra_link_args=extra_link_args
                           )]
 
-if cythonize:
-    extensions = cythonize(extensions, compiler_directives = {'language_level': 3})
-#     extensions = cythonize(extensions, compiler_directives={'linetrace': True})
+if use_cython:
+    extensions = cythonize(extensions, compiler_directives={'language_level': 3})
 
 with open('README.md') as f:
     long_description = f.read()
 
 setup(
-    name = 'PySCIPOpt',
-    version = version,
-    description = 'Python interface and modeling environment for SCIP',
-    long_description = long_description,
+    name='PySCIPOpt',
+    version=version,
+    description='Python interface and modeling environment for SCIP',
+    long_description=long_description,
     long_description_content_type='text/markdown',
-    url = 'https://github.com/SCIP-Interfaces/PySCIPOpt',
-    author = 'Zuse Institute Berlin',
-    author_email = 'scip@zib.de',
-    license = 'MIT',
+    url='https://github.com/SCIP-Interfaces/PySCIPOpt',
+    author='Zuse Institute Berlin',
+    author_email='scip@zib.de',
+    license='MIT',
     classifiers=[
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Science/Research',
-    'Intended Audience :: Education',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Cython',
-    'Topic :: Scientific/Engineering :: Mathematics'],
-    ext_modules = extensions,
-    packages = ['pyscipopt'],
-    package_dir = {'pyscipopt': packagedir},
-    package_data = {'pyscipopt': ['scip.pyx', 'scip.pxd', '*.pxi']}
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'Intended Audience :: Education',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Cython',
+        'Topic :: Scientific/Engineering :: Mathematics'],
+    ext_modules=extensions,
+    packages=['pyscipopt'],
+    package_dir={'pyscipopt': packagedir},
+    package_data={'pyscipopt': ['scip.pyx', 'scip.pxd', '*.pxi']}
 )


### PR DESCRIPTION
Small fix for setup.py. Here, a boolean `cythonize` was introduced that was later overwritten by `from Cython.Build import cythonize`. While `if cythonize` still evaluated to `True` at the right places, I don't think it was intended.

I also changed the formatting a bit to make it look the same (and PEP conform) and removed commented code. If you object, I can reverse those changes.