### PR TITLE
Add method to model for setting the logfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- add SCIP function `SCIPsetMessagehdlrLogfile`
 ### Fixed
 ### Changed
 ### Removed

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -512,6 +512,7 @@ cdef extern from "scip/scip.h":
     SCIP_RETCODE SCIPsetMessagehdlr(SCIP* scip, SCIP_MESSAGEHDLR* messagehdlr)
     void SCIPsetMessagehdlrQuiet(SCIP* scip, SCIP_Bool quiet)
     void SCIPmessageSetErrorPrinting(errormessagecallback, void* data)
+    void SCIPsetMessagehdlrLogfile(SCIP* scip, const char* filename)
     SCIP_Real SCIPversion()
     void SCIPprintVersion(SCIP* scip, FILE* outfile)
     SCIP_Real SCIPgetTotalTime(SCIP* scip)

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -4339,6 +4339,13 @@ cdef class Model:
         PY_SCIP_CALL(SCIPsetMessagehdlr(self._scip, myMessageHandler))
         SCIPmessageSetErrorPrinting(relayErrorMessage, NULL)
 
+    def setLogfile(self, path):
+        """sets the log file name for the currently installed message handler
+        :param path: name of log file, or None (no log)
+        """
+        c_path = str_conversion(path) if path else None
+        SCIPsetMessagehdlrLogfile(self._scip, c_path)
+
     # Parameter Methods
 
     def setBoolParam(self, name, value):


### PR DESCRIPTION
In addition to redirecting the solver's output to Python, it would be useful to save it to a file directly.