### PR TITLE
Fix writing LP to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 ### Fixed
+- fix `Model.writeLP` method
 ### Changed
 ### Removed
 

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -3919,7 +3919,7 @@ cdef class Model:
         :param filename: file name (Default value = "LP.lp")
         """
         absfile = str_conversion(abspath(filename))
-        PY_SCIP_CALL( SCIPwriteLP(self._scip, str_conversion(absfile)) )
+        PY_SCIP_CALL( SCIPwriteLP(self._scip, absfile) )
 
     def createSol(self, Heur heur = None):
         """Create a new primal solution.


### PR DESCRIPTION
Before, the conversion to a byte string was performed twice. This caused a Python error.