### PR TITLE
Ensure GIL during C callbacks

### DIFF
--- a/src/pyscipopt/benders.pxi
+++ b/src/pyscipopt/benders.pxi
@@ -70,10 +70,10 @@ cdef Variable getPyVar(SCIP_VAR* var):
     return <Variable>vardata
 
 
-cdef SCIP_RETCODE PyBendersCopy (SCIP* scip, SCIP_BENDERS* benders, SCIP_Bool threadsafe):
+cdef SCIP_RETCODE PyBendersCopy (SCIP* scip, SCIP_BENDERS* benders, SCIP_Bool threadsafe) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersFree (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersFree (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -81,56 +81,56 @@ cdef SCIP_RETCODE PyBendersFree (SCIP* scip, SCIP_BENDERS* benders):
     Py_DECREF(PyBenders)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersInit (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersInit (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersExit (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersExit (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersInitpre (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersInitpre (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersinitpre()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersExitpre (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersExitpre (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersexitpre()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersInitsol (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersInitsol (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersExitsol (SCIP* scip, SCIP_BENDERS* benders):
+cdef SCIP_RETCODE PyBendersExitsol (SCIP* scip, SCIP_BENDERS* benders) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.bendersexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersCreatesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber):
+cdef SCIP_RETCODE PyBendersCreatesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
     PyBenders.benderscreatesub(probnumber)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersPresubsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* infeasible, SCIP_Bool* auxviol, SCIP_Bool* skipsolve,  SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBendersPresubsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, SCIP_BENDERSENFOTYPE type, SCIP_Bool checkint, SCIP_Bool* infeasible, SCIP_Bool* auxviol, SCIP_Bool* skipsolve,  SCIP_RESULT* result) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -146,7 +146,7 @@ cdef SCIP_RETCODE PyBendersPresubsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersSolvesubconvex (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool onlyconvex, SCIP_Real* objective, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBendersSolvesubconvex (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Bool onlyconvex, SCIP_Real* objective, SCIP_RESULT* result) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -159,7 +159,7 @@ cdef SCIP_RETCODE PyBendersSolvesubconvex (SCIP* scip, SCIP_BENDERS* benders, SC
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersSolvesub (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Real* objective, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBendersSolvesub (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol, int probnumber, SCIP_Real* objective, SCIP_RESULT* result) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -174,7 +174,7 @@ cdef SCIP_RETCODE PyBendersSolvesub (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL
 
 cdef SCIP_RETCODE PyBendersPostsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SOL* sol,
         SCIP_BENDERSENFOTYPE type, int* mergecands, int npriomergecands, int nmergecands, SCIP_Bool checkint,
-        SCIP_Bool infeasible, SCIP_Bool* merged):
+        SCIP_Bool infeasible, SCIP_Bool* merged) with  gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -190,7 +190,7 @@ cdef SCIP_RETCODE PyBendersPostsolve (SCIP* scip, SCIP_BENDERS* benders, SCIP_SO
     merged[0] = result_dict.get("merged", False)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBendersFreesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber):
+cdef SCIP_RETCODE PyBendersFreesub (SCIP* scip, SCIP_BENDERS* benders, int probnumber) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata
@@ -198,7 +198,7 @@ cdef SCIP_RETCODE PyBendersFreesub (SCIP* scip, SCIP_BENDERS* benders, int probn
     return SCIP_OKAY
 
 #TODO: Really need to ask about the passing and returning of variables
-cdef SCIP_RETCODE PyBendersGetvar (SCIP* scip, SCIP_BENDERS* benders, SCIP_VAR* var, SCIP_VAR** mappedvar, int probnumber):
+cdef SCIP_RETCODE PyBendersGetvar (SCIP* scip, SCIP_BENDERS* benders, SCIP_VAR* var, SCIP_VAR** mappedvar, int probnumber) with gil:
     cdef SCIP_BENDERSDATA* bendersdata
     bendersdata = SCIPbendersGetData(benders)
     PyBenders = <Benders>bendersdata

--- a/src/pyscipopt/benderscut.pxi
+++ b/src/pyscipopt/benderscut.pxi
@@ -24,10 +24,10 @@ cdef class Benderscut:
         print("python error in benderscutexec: this method needs to be implemented")
         return {}
 
-cdef SCIP_RETCODE PyBenderscutCopy (SCIP* scip, SCIP_BENDERS* benders, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutCopy (SCIP* scip, SCIP_BENDERS* benders, SCIP_BENDERSCUT* benderscut) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutFree (SCIP* scip, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutFree (SCIP* scip, SCIP_BENDERSCUT* benderscut) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata
@@ -35,35 +35,35 @@ cdef SCIP_RETCODE PyBenderscutFree (SCIP* scip, SCIP_BENDERSCUT* benderscut):
     Py_DECREF(PyBenderscut)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutInit (SCIP* scip, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutInit (SCIP* scip, SCIP_BENDERSCUT* benderscut) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata
     PyBenderscut.benderscutinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutExit (SCIP* scip, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutExit (SCIP* scip, SCIP_BENDERSCUT* benderscut) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata
     PyBenderscut.benderscutexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutInitsol (SCIP* scip, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutInitsol (SCIP* scip, SCIP_BENDERSCUT* benderscut) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata
     PyBenderscut.benderscutinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutExitsol (SCIP* scip, SCIP_BENDERSCUT* benderscut):
+cdef SCIP_RETCODE PyBenderscutExitsol (SCIP* scip, SCIP_BENDERSCUT* benderscut) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata
     PyBenderscut.benderscutexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBenderscutExec (SCIP* scip, SCIP_BENDERS* benders, SCIP_BENDERSCUT* benderscut, SCIP_SOL* sol, int probnumber, SCIP_BENDERSENFOTYPE type, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBenderscutExec (SCIP* scip, SCIP_BENDERS* benders, SCIP_BENDERSCUT* benderscut, SCIP_SOL* sol, int probnumber, SCIP_BENDERSENFOTYPE type, SCIP_RESULT* result) with gil:
     cdef SCIP_BENDERSCUTDATA* benderscutdata
     benderscutdata = SCIPbenderscutGetData(benderscut)
     PyBenderscut = <Benderscut>benderscutdata

--- a/src/pyscipopt/branchrule.pxi
+++ b/src/pyscipopt/branchrule.pxi
@@ -40,10 +40,10 @@ cdef class Branchrule:
 
 
 
-cdef SCIP_RETCODE PyBranchruleCopy (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleCopy (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleFree (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleFree (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
@@ -51,35 +51,35 @@ cdef SCIP_RETCODE PyBranchruleFree (SCIP* scip, SCIP_BRANCHRULE* branchrule):
     Py_DECREF(PyBranchrule)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleInit (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleInit (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
     PyBranchrule.branchinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleExit (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleExit (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
     PyBranchrule.branchexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleInitsol (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleInitsol (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
     PyBranchrule.branchinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleExitsol (SCIP* scip, SCIP_BRANCHRULE* branchrule):
+cdef SCIP_RETCODE PyBranchruleExitsol (SCIP* scip, SCIP_BRANCHRULE* branchrule) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
     PyBranchrule.branchexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleExeclp (SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBranchruleExeclp (SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
@@ -87,7 +87,7 @@ cdef SCIP_RETCODE PyBranchruleExeclp (SCIP* scip, SCIP_BRANCHRULE* branchrule, S
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleExecext(SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBranchruleExecext(SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata
@@ -95,7 +95,7 @@ cdef SCIP_RETCODE PyBranchruleExecext(SCIP* scip, SCIP_BRANCHRULE* branchrule, S
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyBranchruleExecps(SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyBranchruleExecps(SCIP* scip, SCIP_BRANCHRULE* branchrule, SCIP_Bool allowaddcons, SCIP_RESULT* result) with gil:
     cdef SCIP_BRANCHRULEDATA* branchruledata
     branchruledata = SCIPbranchruleGetData(branchrule)
     PyBranchrule = <Branchrule>branchruledata

--- a/src/pyscipopt/conshdlr.pxi
+++ b/src/pyscipopt/conshdlr.pxi
@@ -150,16 +150,16 @@ cdef Constraint getPyCons(SCIP_CONS* cons):
 
 
 
-cdef SCIP_RETCODE PyConshdlrCopy (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_Bool* valid):
+cdef SCIP_RETCODE PyConshdlrCopy (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_Bool* valid) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsFree (SCIP* scip, SCIP_CONSHDLR* conshdlr):
+cdef SCIP_RETCODE PyConsFree (SCIP* scip, SCIP_CONSHDLR* conshdlr) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyConshdlr.consfree()
     Py_DECREF(PyConshdlr)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsInit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsInit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -167,7 +167,7 @@ cdef SCIP_RETCODE PyConsInit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** c
     PyConshdlr.consinit(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsExit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsExit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -175,7 +175,7 @@ cdef SCIP_RETCODE PyConsExit (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** c
     PyConshdlr.consexit(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsInitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsInitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -183,7 +183,7 @@ cdef SCIP_RETCODE PyConsInitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     PyConshdlr.consinitpre(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsExitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsExitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -191,7 +191,7 @@ cdef SCIP_RETCODE PyConsExitpre (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     PyConshdlr.consexitpre(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsInitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsInitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -199,7 +199,7 @@ cdef SCIP_RETCODE PyConsInitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     PyConshdlr.consinitsol(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsExitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, SCIP_Bool restart):
+cdef SCIP_RETCODE PyConsExitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, SCIP_Bool restart) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -207,7 +207,7 @@ cdef SCIP_RETCODE PyConsExitsol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     PyConshdlr.consexitsol(constraints, restart)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsDelete (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_CONSDATA** consdata):
+cdef SCIP_RETCODE PyConsDelete (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_CONSDATA** consdata) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     assert <Constraint>consdata[0] == PyCons
@@ -216,7 +216,7 @@ cdef SCIP_RETCODE PyConsDelete (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* 
     Py_DECREF(PyCons)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsTrans (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* sourcecons, SCIP_CONS** targetcons):
+cdef SCIP_RETCODE PyConsTrans (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* sourcecons, SCIP_CONS** targetcons) with gil:
     cdef Constraint PyTargetCons
     PyConshdlr = getPyConshdlr(conshdlr)
     PySourceCons = getPyCons(sourcecons)
@@ -235,7 +235,7 @@ cdef SCIP_RETCODE PyConsTrans (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* s
             PySourceCons.isRemovable(), PySourceCons.isStickingAtNode()))
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsInitlp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, SCIP_Bool* infeasible):
+cdef SCIP_RETCODE PyConsInitlp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, SCIP_Bool* infeasible) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -244,7 +244,7 @@ cdef SCIP_RETCODE PyConsInitlp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
     infeasible[0] = result_dict.get("infeasible", infeasible[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsSepalp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyConsSepalp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -254,7 +254,7 @@ cdef SCIP_RETCODE PyConsSepalp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsSepasol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss,
-                                 SCIP_SOL* sol, SCIP_RESULT* result):
+                                 SCIP_SOL* sol, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -265,7 +265,7 @@ cdef SCIP_RETCODE PyConsSepasol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsEnfolp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss,
-                                SCIP_Bool solinfeasible, SCIP_RESULT* result):
+                                SCIP_Bool solinfeasible, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -274,7 +274,7 @@ cdef SCIP_RETCODE PyConsEnfolp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsEnforelax (SCIP* scip, SCIP_SOL* sol, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss, SCIP_Bool solinfeasible, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyConsEnforelax (SCIP* scip, SCIP_SOL* sol, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss, SCIP_Bool solinfeasible, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -285,7 +285,7 @@ cdef SCIP_RETCODE PyConsEnforelax (SCIP* scip, SCIP_SOL* sol, SCIP_CONSHDLR* con
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsEnfops (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss,
-                                SCIP_Bool solinfeasible, SCIP_Bool objinfeasible, SCIP_RESULT* result):
+                                SCIP_Bool solinfeasible, SCIP_Bool objinfeasible, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -295,7 +295,7 @@ cdef SCIP_RETCODE PyConsEnfops (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsCheck (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, SCIP_SOL* sol, SCIP_Bool checkintegrality,
-                               SCIP_Bool checklprows, SCIP_Bool printreason, SCIP_Bool completely, SCIP_RESULT* result):
+                               SCIP_Bool checklprows, SCIP_Bool printreason, SCIP_Bool completely, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -306,7 +306,7 @@ cdef SCIP_RETCODE PyConsCheck (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** 
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsProp (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss, int nusefulconss, int nmarkedconss,
-                              SCIP_PROPTIMING proptiming, SCIP_RESULT* result):
+                              SCIP_PROPTIMING proptiming, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -319,7 +319,7 @@ cdef SCIP_RETCODE PyConsPresol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
                                 int nnewfixedvars, int nnewaggrvars, int nnewchgvartypes, int nnewchgbds, int nnewholes,
                                 int nnewdelconss, int nnewaddconss, int nnewupgdconss, int nnewchgcoefs, int nnewchgsides,
                                 int* nfixedvars, int* naggrvars, int* nchgvartypes, int* nchgbds, int* naddholes,
-                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result):
+                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -354,12 +354,12 @@ cdef SCIP_RETCODE PyConsPresol (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS**
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsResprop (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_VAR* infervar, int inferinfo,
-                                 SCIP_BOUNDTYPE boundtype, SCIP_BDCHGIDX* bdchgidx, SCIP_Real relaxedbd, SCIP_RESULT* result):
+                                 SCIP_BOUNDTYPE boundtype, SCIP_BDCHGIDX* bdchgidx, SCIP_Real relaxedbd, SCIP_RESULT* result) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyConshdlr.consresprop()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsLock (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_LOCKTYPE locktype, int nlockspos, int nlocksneg):
+cdef SCIP_RETCODE PyConsLock (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_LOCKTYPE locktype, int nlockspos, int nlocksneg) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     if cons == NULL:
         PyConshdlr.conslock(None, locktype, nlockspos, nlocksneg)
@@ -368,31 +368,31 @@ cdef SCIP_RETCODE PyConsLock (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* co
         PyConshdlr.conslock(PyCons, locktype, nlockspos, nlocksneg)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsActive (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons):
+cdef SCIP_RETCODE PyConsActive (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     PyConshdlr.consactive(PyCons)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsDeactive (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons):
+cdef SCIP_RETCODE PyConsDeactive (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     PyConshdlr.consdeactive(PyCons)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsEnable (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons):
+cdef SCIP_RETCODE PyConsEnable (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     PyConshdlr.consenable(PyCons)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsDisable (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons):
+cdef SCIP_RETCODE PyConsDisable (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     PyConshdlr.consdisable(PyCons)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsDelvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss):
+cdef SCIP_RETCODE PyConsDelvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** conss, int nconss) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     cdef constraints = []
     for i in range(nconss):
@@ -400,7 +400,7 @@ cdef SCIP_RETCODE PyConsDelvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     PyConshdlr.consdelvars(constraints)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsPrint (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, FILE* file):
+cdef SCIP_RETCODE PyConsPrint (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, FILE* file) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     # TODO: pass file
@@ -411,7 +411,7 @@ cdef SCIP_RETCODE PyConsCopy (SCIP* scip, SCIP_CONS** cons, const char* name, SC
                               SCIP_CONS* sourcecons, SCIP_HASHMAP* varmap, SCIP_HASHMAP* consmap, SCIP_Bool initial,
                               SCIP_Bool separate, SCIP_Bool enforce, SCIP_Bool check, SCIP_Bool propagate, SCIP_Bool local,
                               SCIP_Bool modifiable, SCIP_Bool dynamic, SCIP_Bool removable, SCIP_Bool stickingatnode,
-                              SCIP_Bool isglobal, SCIP_Bool* valid):
+                              SCIP_Bool isglobal, SCIP_Bool* valid) with gil:
     # TODO everything!
     PyConshdlr = getPyConshdlr(sourceconshdlr)
     PyConshdlr.conscopy()
@@ -421,14 +421,14 @@ cdef SCIP_RETCODE PyConsCopy (SCIP* scip, SCIP_CONS** cons, const char* name, SC
 cdef SCIP_RETCODE PyConsParse (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS** cons, const char* name, const char* str,
                                SCIP_Bool initial, SCIP_Bool separate, SCIP_Bool enforce, SCIP_Bool check, SCIP_Bool propagate,
                                SCIP_Bool local, SCIP_Bool modifiable, SCIP_Bool dynamic, SCIP_Bool removable,
-                               SCIP_Bool stickingatnode, SCIP_Bool* success):
+                               SCIP_Bool stickingatnode, SCIP_Bool* success) with gil:
     # TODO everything!
     PyConshdlr = getPyConshdlr(conshdlr)
     PyConshdlr.consparse()
     success[0] = False
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsGetvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_VAR** vars, int varssize, SCIP_Bool* success):
+cdef SCIP_RETCODE PyConsGetvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, SCIP_VAR** vars, int varssize, SCIP_Bool* success) with gil:
     # TODO
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
@@ -436,7 +436,7 @@ cdef SCIP_RETCODE PyConsGetvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS*
     success[0] = False
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyConsGetnvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, int* nvars, SCIP_Bool* success):
+cdef SCIP_RETCODE PyConsGetnvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS* cons, int* nvars, SCIP_Bool* success) with gil:
     PyConshdlr = getPyConshdlr(conshdlr)
     PyCons = getPyCons(cons)
     result_dict = PyConshdlr.consgetnvars(PyCons)
@@ -445,7 +445,7 @@ cdef SCIP_RETCODE PyConsGetnvars (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_CONS
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyConsGetdivebdchgs (SCIP* scip, SCIP_CONSHDLR* conshdlr, SCIP_DIVESET* diveset, SCIP_SOL* sol,
-                                       SCIP_Bool* success, SCIP_Bool* infeasible):
+                                       SCIP_Bool* success, SCIP_Bool* infeasible) with gil:
     # TODO
     PyConshdlr = getPyConshdlr(conshdlr)
     PyConshdlr.consgetdivebdchgs()

--- a/src/pyscipopt/event.pxi
+++ b/src/pyscipopt/event.pxi
@@ -39,48 +39,48 @@ cdef class Eventhdlr:
 
 
 # local helper functions for the interface
-cdef Eventhdlr getPyEventhdlr(SCIP_EVENTHDLR* eventhdlr):
+cdef Eventhdlr getPyEventhdlr(SCIP_EVENTHDLR* eventhdlr) with gil:
     cdef SCIP_EVENTHDLRDATA* eventhdlrdata
     eventhdlrdata = SCIPeventhdlrGetData(eventhdlr)
     return <Eventhdlr>eventhdlrdata
 
-cdef SCIP_RETCODE PyEventCopy (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventCopy (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventcopy()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventFree (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventFree (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventfree()
     Py_DECREF(PyEventhdlr)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventInit (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventInit (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventExit (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventExit (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventInitsol (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventInitsol (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventExitsol (SCIP* scip, SCIP_EVENTHDLR* eventhdlr):
+cdef SCIP_RETCODE PyEventExitsol (SCIP* scip, SCIP_EVENTHDLR* eventhdlr) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventDelete (SCIP* scip, SCIP_EVENTHDLR* eventhdlr, SCIP_EVENTDATA** eventdata):
+cdef SCIP_RETCODE PyEventDelete (SCIP* scip, SCIP_EVENTHDLR* eventhdlr, SCIP_EVENTDATA** eventdata) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEventhdlr.eventdelete()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyEventExec (SCIP* scip, SCIP_EVENTHDLR* eventhdlr, SCIP_EVENT* event, SCIP_EVENTDATA* eventdata):
+cdef SCIP_RETCODE PyEventExec (SCIP* scip, SCIP_EVENTHDLR* eventhdlr, SCIP_EVENT* event, SCIP_EVENTDATA* eventdata) with gil:
     PyEventhdlr = getPyEventhdlr(eventhdlr)
     PyEvent = Event()
     PyEvent.event = event

--- a/src/pyscipopt/heuristic.pxi
+++ b/src/pyscipopt/heuristic.pxi
@@ -31,10 +31,10 @@ cdef class Heur:
 
 
 
-cdef SCIP_RETCODE PyHeurCopy (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurCopy (SCIP* scip, SCIP_HEUR* heur) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurFree (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurFree (SCIP* scip, SCIP_HEUR* heur) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata
@@ -42,35 +42,35 @@ cdef SCIP_RETCODE PyHeurFree (SCIP* scip, SCIP_HEUR* heur):
     Py_DECREF(PyHeur)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurInit (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurInit (SCIP* scip, SCIP_HEUR* heur) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata
     PyHeur.heurinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurExit (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurExit (SCIP* scip, SCIP_HEUR* heur) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata
     PyHeur.heurexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurInitsol (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurInitsol (SCIP* scip, SCIP_HEUR* heur) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata
     PyHeur.heurinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurExitsol (SCIP* scip, SCIP_HEUR* heur):
+cdef SCIP_RETCODE PyHeurExitsol (SCIP* scip, SCIP_HEUR* heur) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata
     PyHeur.heurexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyHeurExec (SCIP* scip, SCIP_HEUR* heur, SCIP_HEURTIMING heurtiming, SCIP_Bool nodeinfeasible, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyHeurExec (SCIP* scip, SCIP_HEUR* heur, SCIP_HEURTIMING heurtiming, SCIP_Bool nodeinfeasible, SCIP_RESULT* result) with gil:
     cdef SCIP_HEURDATA* heurdata
     heurdata = SCIPheurGetData(heur)
     PyHeur = <Heur>heurdata

--- a/src/pyscipopt/nodesel.pxi
+++ b/src/pyscipopt/nodesel.pxi
@@ -42,10 +42,10 @@ cdef class Nodesel:
     return 0
 
 
-cdef SCIP_RETCODE PyNodeselCopy (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselCopy (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   return SCIP_OKAY
 
-cdef SCIP_RETCODE PyNodeselFree (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselFree (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata
@@ -53,7 +53,7 @@ cdef SCIP_RETCODE PyNodeselFree (SCIP* scip, SCIP_NODESEL* nodesel):
   Py_DECREF(PyNodesel)
   return SCIP_OKAY
 
-cdef SCIP_RETCODE PyNodeselInit (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselInit (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata
@@ -61,28 +61,28 @@ cdef SCIP_RETCODE PyNodeselInit (SCIP* scip, SCIP_NODESEL* nodesel):
   return SCIP_OKAY
 
 
-cdef SCIP_RETCODE PyNodeselExit (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselExit (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata
   PyNodesel.nodeexit()
   return SCIP_OKAY
 
-cdef SCIP_RETCODE PyNodeselInitsol (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselInitsol (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata
   PyNodesel.nodeinitsol()
   return SCIP_OKAY
 
-cdef SCIP_RETCODE PyNodeselExitsol (SCIP* scip, SCIP_NODESEL* nodesel):
+cdef SCIP_RETCODE PyNodeselExitsol (SCIP* scip, SCIP_NODESEL* nodesel) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata
   PyNodesel.nodeexitsol()
   return SCIP_OKAY
 
-cdef SCIP_RETCODE PyNodeselSelect (SCIP* scip, SCIP_NODESEL* nodesel, SCIP_NODE** selnode):
+cdef SCIP_RETCODE PyNodeselSelect (SCIP* scip, SCIP_NODESEL* nodesel, SCIP_NODE** selnode) with gil:
   cdef SCIP_NODESELDATA* nodeseldata
   nodeseldata = SCIPnodeselGetData(nodesel)
   PyNodesel = <Nodesel>nodeseldata

--- a/src/pyscipopt/presol.pxi
+++ b/src/pyscipopt/presol.pxi
@@ -30,10 +30,10 @@ cdef class Presol:
 
 
 
-cdef SCIP_RETCODE PyPresolCopy (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolCopy (SCIP* scip, SCIP_PRESOL* presol) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPresolFree (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolFree (SCIP* scip, SCIP_PRESOL* presol) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata
@@ -41,14 +41,14 @@ cdef SCIP_RETCODE PyPresolFree (SCIP* scip, SCIP_PRESOL* presol):
     Py_DECREF(PyPresol)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPresolInit (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolInit (SCIP* scip, SCIP_PRESOL* presol) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata
     PyPresol.presolinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPresolExit (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolExit (SCIP* scip, SCIP_PRESOL* presol) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata
@@ -56,14 +56,14 @@ cdef SCIP_RETCODE PyPresolExit (SCIP* scip, SCIP_PRESOL* presol):
     return SCIP_OKAY
 
 
-cdef SCIP_RETCODE PyPresolInitpre (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolInitpre (SCIP* scip, SCIP_PRESOL* presol) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata
     PyPresol.presolinitpre()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPresolExitpre (SCIP* scip, SCIP_PRESOL* presol):
+cdef SCIP_RETCODE PyPresolExitpre (SCIP* scip, SCIP_PRESOL* presol) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata
@@ -74,7 +74,7 @@ cdef SCIP_RETCODE PyPresolExec (SCIP* scip, SCIP_PRESOL* presol, int nrounds, SC
                                 int nnewfixedvars, int nnewaggrvars, int nnewchgvartypes, int nnewchgbds, int nnewholes,
                                 int nnewdelconss, int nnewaddconss, int nnewupgdconss, int nnewchgcoefs, int nnewchgsides,
                                 int* nfixedvars, int* naggrvars, int* nchgvartypes, int* nchgbds, int* naddholes,
-                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result):
+                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result) with gil:
     cdef SCIP_PRESOLDATA* presoldata
     presoldata = SCIPpresolGetData(presol)
     PyPresol = <Presol>presoldata

--- a/src/pyscipopt/pricer.pxi
+++ b/src/pyscipopt/pricer.pxi
@@ -34,10 +34,10 @@ cdef class Pricer:
 
 
 
-cdef SCIP_RETCODE PyPricerCopy (SCIP* scip, SCIP_PRICER* pricer, SCIP_Bool* valid):
+cdef SCIP_RETCODE PyPricerCopy (SCIP* scip, SCIP_PRICER* pricer, SCIP_Bool* valid) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerFree (SCIP* scip, SCIP_PRICER* pricer):
+cdef SCIP_RETCODE PyPricerFree (SCIP* scip, SCIP_PRICER* pricer) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
@@ -45,35 +45,35 @@ cdef SCIP_RETCODE PyPricerFree (SCIP* scip, SCIP_PRICER* pricer):
     Py_DECREF(PyPricer)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerInit (SCIP* scip, SCIP_PRICER* pricer):
+cdef SCIP_RETCODE PyPricerInit (SCIP* scip, SCIP_PRICER* pricer) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
     PyPricer.pricerinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerExit (SCIP* scip, SCIP_PRICER* pricer):
+cdef SCIP_RETCODE PyPricerExit (SCIP* scip, SCIP_PRICER* pricer) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
     PyPricer.pricerexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerInitsol (SCIP* scip, SCIP_PRICER* pricer):
+cdef SCIP_RETCODE PyPricerInitsol (SCIP* scip, SCIP_PRICER* pricer) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
     PyPricer.pricerinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerExitsol (SCIP* scip, SCIP_PRICER* pricer):
+cdef SCIP_RETCODE PyPricerExitsol (SCIP* scip, SCIP_PRICER* pricer) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
     PyPricer.pricerexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerRedcost (SCIP* scip, SCIP_PRICER* pricer, SCIP_Real* lowerbound, SCIP_Bool* stopearly, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyPricerRedcost (SCIP* scip, SCIP_PRICER* pricer, SCIP_Real* lowerbound, SCIP_Bool* stopearly, SCIP_RESULT* result) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata
@@ -83,7 +83,7 @@ cdef SCIP_RETCODE PyPricerRedcost (SCIP* scip, SCIP_PRICER* pricer, SCIP_Real* l
     stopearly[0] = result_dict.get("stopearly", <SCIP_Bool>stopearly[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPricerFarkas (SCIP* scip, SCIP_PRICER* pricer, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyPricerFarkas (SCIP* scip, SCIP_PRICER* pricer, SCIP_RESULT* result) with gil:
     cdef SCIP_PRICERDATA* pricerdata
     pricerdata = SCIPpricerGetData(pricer)
     PyPricer = <Pricer>pricerdata

--- a/src/pyscipopt/propagator.pxi
+++ b/src/pyscipopt/propagator.pxi
@@ -47,10 +47,10 @@ cdef class Prop:
 
 
 
-cdef SCIP_RETCODE PyPropCopy (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropCopy (SCIP* scip, SCIP_PROP* prop) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropFree (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropFree (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
@@ -58,42 +58,42 @@ cdef SCIP_RETCODE PyPropFree (SCIP* scip, SCIP_PROP* prop):
     Py_DECREF(PyProp)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropInit (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropInit (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
     PyProp.propinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropExit (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropExit (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
     PyProp.propexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropInitpre (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropInitpre (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
     PyProp.propinitpre()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropExitpre (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropExitpre (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
     PyProp.propexitpre()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropInitsol (SCIP* scip, SCIP_PROP* prop):
+cdef SCIP_RETCODE PyPropInitsol (SCIP* scip, SCIP_PROP* prop) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
     PyProp.propinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropExitsol (SCIP* scip, SCIP_PROP* prop, SCIP_Bool restart):
+cdef SCIP_RETCODE PyPropExitsol (SCIP* scip, SCIP_PROP* prop, SCIP_Bool restart) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
@@ -104,7 +104,7 @@ cdef SCIP_RETCODE PyPropPresol (SCIP* scip, SCIP_PROP* prop, int nrounds, SCIP_P
                                 int nnewfixedvars, int nnewaggrvars, int nnewchgvartypes, int nnewchgbds, int nnewholes,
                                 int nnewdelconss, int nnewaddconss, int nnewupgdconss, int nnewchgcoefs, int nnewchgsides,
                                 int* nfixedvars, int* naggrvars, int* nchgvartypes, int* nchgbds, int* naddholes,
-                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result):
+                                int* ndelconss, int* naddconss, int* nupgdconss, int* nchgcoefs, int* nchgsides, SCIP_RESULT* result) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
@@ -137,7 +137,7 @@ cdef SCIP_RETCODE PyPropPresol (SCIP* scip, SCIP_PROP* prop, int nrounds, SCIP_P
     nchgsides[0]    = result_dict["nchgsides"]
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyPropExec (SCIP* scip, SCIP_PROP* prop, SCIP_PROPTIMING proptiming, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyPropExec (SCIP* scip, SCIP_PROP* prop, SCIP_PROPTIMING proptiming, SCIP_RESULT* result) with gil:
     cdef SCIP_PROPDATA* propdata
     propdata = SCIPpropGetData(prop)
     PyProp = <Prop>propdata
@@ -147,7 +147,7 @@ cdef SCIP_RETCODE PyPropExec (SCIP* scip, SCIP_PROP* prop, SCIP_PROPTIMING propt
     return SCIP_OKAY
 
 cdef SCIP_RETCODE PyPropResProp (SCIP* scip, SCIP_PROP* prop, SCIP_VAR* infervar, int inferinfo,
-                                 SCIP_BOUNDTYPE boundtype, SCIP_BDCHGIDX* bdchgidx, SCIP_Real relaxedbd, SCIP_RESULT* result):
+                                 SCIP_BOUNDTYPE boundtype, SCIP_BDCHGIDX* bdchgidx, SCIP_Real relaxedbd, SCIP_RESULT* result) with gil:
     cdef SCIP_PROPDATA* propdata
     cdef SCIP_VAR* tmp
     tmp = infervar

--- a/src/pyscipopt/relax.pxi
+++ b/src/pyscipopt/relax.pxi
@@ -30,10 +30,10 @@ cdef class Relax:
         return{}
 
 
-cdef SCIP_RETCODE PyRelaxCopy (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxCopy (SCIP* scip, SCIP_RELAX* relax) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxFree (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxFree (SCIP* scip, SCIP_RELAX* relax) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata
@@ -41,35 +41,35 @@ cdef SCIP_RETCODE PyRelaxFree (SCIP* scip, SCIP_RELAX* relax):
     Py_DECREF(PyRelax)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxInit (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxInit (SCIP* scip, SCIP_RELAX* relax) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata
     PyRelax.relaxinit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxExit (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxExit (SCIP* scip, SCIP_RELAX* relax) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata
     PyRelax.relaxexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxInitsol (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxInitsol (SCIP* scip, SCIP_RELAX* relax) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata
     PyRelax.relaxinitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxExitsol (SCIP* scip, SCIP_RELAX* relax):
+cdef SCIP_RETCODE PyRelaxExitsol (SCIP* scip, SCIP_RELAX* relax) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata
     PyRelax.relaxexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PyRelaxExec (SCIP* scip, SCIP_RELAX* relax, SCIP_Real* lowerbound, SCIP_RESULT* result):
+cdef SCIP_RETCODE PyRelaxExec (SCIP* scip, SCIP_RELAX* relax, SCIP_Real* lowerbound, SCIP_RESULT* result) with gil:
     cdef SCIP_RELAXDATA* relaxdata
     relaxdata = SCIPrelaxGetData(relax)
     PyRelax = <Relax>relaxdata

--- a/src/pyscipopt/sepa.pxi
+++ b/src/pyscipopt/sepa.pxi
@@ -34,10 +34,10 @@ cdef class Sepa:
 
 
 
-cdef SCIP_RETCODE PySepaCopy (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaCopy (SCIP* scip, SCIP_SEPA* sepa) with gil:
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaFree (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaFree (SCIP* scip, SCIP_SEPA* sepa) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
@@ -45,35 +45,35 @@ cdef SCIP_RETCODE PySepaFree (SCIP* scip, SCIP_SEPA* sepa):
     Py_DECREF(PySepa)
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaInit (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaInit (SCIP* scip, SCIP_SEPA* sepa) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
     PySepa.sepainit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaExit (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaExit (SCIP* scip, SCIP_SEPA* sepa) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
     PySepa.sepaexit()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaInitsol (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaInitsol (SCIP* scip, SCIP_SEPA* sepa) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
     PySepa.sepainitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaExitsol (SCIP* scip, SCIP_SEPA* sepa):
+cdef SCIP_RETCODE PySepaExitsol (SCIP* scip, SCIP_SEPA* sepa) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
     PySepa.sepaexitsol()
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaExeclp (SCIP* scip, SCIP_SEPA* sepa, SCIP_RESULT* result, unsigned int allowlocal):
+cdef SCIP_RETCODE PySepaExeclp (SCIP* scip, SCIP_SEPA* sepa, SCIP_RESULT* result, unsigned int allowlocal) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     PySepa = <Sepa>sepadata
@@ -81,7 +81,7 @@ cdef SCIP_RETCODE PySepaExeclp (SCIP* scip, SCIP_SEPA* sepa, SCIP_RESULT* result
     result[0] = result_dict.get("result", <SCIP_RESULT>result[0])
     return SCIP_OKAY
 
-cdef SCIP_RETCODE PySepaExecsol (SCIP* scip, SCIP_SEPA* sepa, SCIP_SOL* sol, SCIP_RESULT* result, unsigned int allowlocal):
+cdef SCIP_RETCODE PySepaExecsol (SCIP* scip, SCIP_SEPA* sepa, SCIP_SOL* sol, SCIP_RESULT* result, unsigned int allowlocal) with gil:
     cdef SCIP_SEPADATA* sepadata
     sepadata = SCIPsepaGetData(sepa)
     solution = Solution.create(scip, sol)


### PR DESCRIPTION
During all C callbacks ensure that the GIL is held before executing Python code.

In Ecole we don't hold the GIL when calling `SCIPsolve`, so if users have added a callback through Python, user would get
```
Fatal Python error: PyThreadState_Get: no current thread
```

This is a prerequisite to  #430 , but I think it we should do a bit more testing before actually removing the GIL in intensive methods.