### PR TITLE
Add convenience function to add multiple constraints at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- add convenience function `Model.addConss()` to add multiple constraints at once
 ### Fixed
 ### Changed
 ### Removed

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -1979,18 +1979,19 @@ cdef class Model:
                 stickingatnode=False):
         """Add a linear or quadratic constraint.
 
-        :param cons: list of coefficients
+        :param cons: constraint object
         :param name: the name of the constraint, generic name if empty (Default value = '')
         :param initial: should the LP relaxation of constraint be in the initial LP? (Default value = True)
         :param separate: should the constraint be separated during LP processing? (Default value = True)
         :param enforce: should the constraint be enforced during node processing? (Default value = True)
-        :param check: should the constraint be checked during for feasibility? (Default value = True)
+        :param check: should the constraint be checked for feasibility? (Default value = True)
         :param propagate: should the constraint be propagated during node processing? (Default value = True)
         :param local: is the constraint only valid locally? (Default value = False)
         :param modifiable: is the constraint modifiable (subject to column generation)? (Default value = False)
         :param dynamic: is the constraint subject to aging? (Default value = False)
         :param removable: should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
         :param stickingatnode: should the constraint always be kept at the node where it was added, even if it may be  moved to a more global node? (Default value = False)
+        :return The added @ref scip#Constraint "Constraint" object.
 
         """
         assert isinstance(cons, ExprCons), "given constraint is not ExprCons but %s" % cons.__class__.__name__

--- a/src/pyscipopt/scip.pyx
+++ b/src/pyscipopt/scip.pyx
@@ -12,6 +12,9 @@ from cpython.pycapsule cimport PyCapsule_New, PyCapsule_IsValid, PyCapsule_GetPo
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport fdopen
 
+from collections.abc import Iterable
+from itertools import repeat
+
 include "expr.pxi"
 include "lp.pxi"
 include "benders.pxi"
@@ -2018,6 +2021,71 @@ cdef class Model:
             return self._addGenNonlinearCons(cons, **kwargs)
         else:
             return self._addNonlinearCons(cons, **kwargs)
+
+    def addConss(self, conss, name='', initial=True, separate=True,
+                 enforce=True, check=True, propagate=True, local=False,
+                 modifiable=False, dynamic=False, removable=False,
+                 stickingatnode=False):
+        """Adds multiple linear or quadratic constraints.
+
+        Each of the constraints is added to the model using Model.addCons().
+
+        For all parameters, except @p conss, this method behaves differently depending on the type of the passed argument:
+          1. If the value is iterable, it must be of the same length as @p conss. For each constraint, Model.addCons() will be called with the value at the corresponding index.
+          2. Else, the (default) value will be applied to all of the constraints.
+
+        :param conss An iterable of constraint objects. Any iterable will be converted into a list before further processing.
+        :param name: the names of the constraints, generic name if empty (Default value = ''). If a single string is passed, it will be suffixed by an underscore and the enumerated index of the constraint (starting with 0).
+        :param initial: should the LP relaxation of constraints be in the initial LP? (Default value = True)
+        :param separate: should the constraints be separated during LP processing? (Default value = True)
+        :param enforce: should the constraints be enforced during node processing? (Default value = True)
+        :param check: should the constraints be checked for feasibility? (Default value = True)
+        :param propagate: should the constraints be propagated during node processing? (Default value = True)
+        :param local: are the constraints only valid locally? (Default value = False)
+        :param modifiable: are the constraints modifiable (subject to column generation)? (Default value = False)
+        :param dynamic: are the constraints subject to aging? (Default value = False)
+        :param removable: should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
+        :param stickingatnode: should the constraints always be kept at the node where it was added, even if it may be  @oved to a more global node? (Default value = False)
+        :return A list of added @ref scip#Constraint "Constraint" objects.
+
+        :see addCons()
+        """
+        def ensure_iterable(elem, length):
+            if isinstance(elem, Iterable):
+                return elem
+            else:
+                return list(repeat(elem, length))
+
+        assert isinstance(conss, Iterable), "Given constraint list is not iterable."
+
+        conss = list(conss)
+        n_conss = len(conss)
+
+        if isinstance(name, str):
+            if name == "":
+                name = ["" for idx in range(n_conss)]
+            else:
+                name = ["%s_%s" % (name, idx) for idx in range(n_conss)]
+        initial = ensure_iterable(initial, n_conss)
+        separate = ensure_iterable(separate, n_conss)
+        enforce = ensure_iterable(enforce, n_conss)
+        check = ensure_iterable(check, n_conss)
+        propagate = ensure_iterable(propagate, n_conss)
+        local = ensure_iterable(local, n_conss)
+        modifiable = ensure_iterable(modifiable, n_conss)
+        dynamic = ensure_iterable(dynamic, n_conss)
+        removable = ensure_iterable(removable, n_conss)
+        stickingatnode = ensure_iterable(stickingatnode, n_conss)
+
+        constraints = []
+        for i, cons in enumerate(conss):
+            constraints.append(
+                self.addCons(cons, name[i], initial[i], separate[i], enforce[i],
+                             check[i], propagate[i], local[i], modifiable[i],
+                             dynamic[i], removable[i], stickingatnode[i])
+            )
+
+        return constraints
 
     def _addLinCons(self, ExprCons lincons, **kwargs):
         assert isinstance(lincons, ExprCons), "given constraint is not ExprCons but %s" % lincons.__class__.__name__

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,6 +79,89 @@ def test_model():
     assert s.getStatus() == 'unbounded'
 
 
+def test_multiple_cons_simple():
+    def assert_conss_eq(a, b):
+        assert a.name == b.name
+        assert a.isInitial() == b.isInitial()
+        assert a.isSeparated() == b.isSeparated()
+        assert a.isEnforced() == b.isEnforced()
+        assert a.isChecked() == b.isChecked()
+        assert a.isPropagated() == b.isPropagated()
+        assert a.isLocal() == b.isLocal()
+        assert a.isModifiable() == b.isModifiable()
+        assert a.isDynamic() == b.isDynamic()
+        assert a.isRemovable() == b.isRemovable()
+        assert a.isStickingAtNode() == b.isStickingAtNode()
+
+    s = Model()
+    s_x = s.addVar("x", vtype = 'C', obj = 1.0)
+    s_y = s.addVar("y", vtype = 'C', obj = 2.0)
+    s_cons = s.addCons(s_x + 2 * s_y <= 1.0)
+
+    m = Model()
+    m_x = m.addVar("x", vtype = 'C', obj = 1.0)
+    m_y = m.addVar("y", vtype = 'C', obj = 2.0)
+    m_conss = m.addConss([m_x + 2 * m_y <= 1.0])
+
+    assert len(m_conss) == 1
+    assert_conss_eq(s_cons, m_conss[0])
+
+    s.freeProb()
+    m.freeProb()
+
+
+def test_multiple_cons_names():
+    m = Model()
+    x = m.addVar("x", vtype = 'C', obj = 1.0)
+    y = m.addVar("y", vtype = 'C', obj = 2.0)
+
+    names = list("abcdef")
+    conss = m.addConss([x + 2 * y <= 1 for i in range(len(names))], names)
+
+    assert len(conss) == len(names)
+    assert all([c.name == n for c, n in zip(conss, names)])
+
+    m.freeProb()
+
+    m = Model()
+    x = m.addVar("x", vtype = 'C', obj = 1.0)
+    y = m.addVar("y", vtype = 'C', obj = 2.0)
+
+    name = "abcdef"
+    conss = m.addConss([x + 2 * y <= 1 for i in range(5)], name)
+
+    assert len(conss) == 5
+    assert all([c.name.startswith(name + "_") for c in conss])
+
+
+def test_multiple_cons_params():
+    """Test if setting the remaining parameters works as expected"""
+    def assert_conss_neq(a, b):
+        assert a.isInitial() != b.isInitial()
+        assert a.isSeparated() != b.isSeparated()
+        assert a.isEnforced() != b.isEnforced()
+        assert a.isChecked() != b.isChecked()
+        assert a.isPropagated() != b.isPropagated()
+        assert a.isModifiable() != b.isModifiable()
+        assert a.isDynamic() != b.isDynamic()
+        assert a.isRemovable() != b.isRemovable()
+        assert a.isStickingAtNode() != b.isStickingAtNode()
+
+    kwargs = dict(initial=True, separate=True,
+                  enforce=True, check=True, propagate=True, local=False,
+                  modifiable=False, dynamic=False, removable=False,
+                  stickingatnode=False)
+
+    m = Model()
+    x = m.addVar("x", vtype = 'C', obj = 1.0)
+    y = m.addVar("y", vtype = 'C', obj = 2.0)
+
+    conss = m.addConss([x + 2 * y <= 1], **kwargs)
+    conss += m.addConss([x + 2 * y <= 1], **{k: not v for k, v in kwargs.items()})
+
+    assert_conss_neq(conss[0], conss[1])
+
+
 def test_model_ptr():
     model1 = Model()
     ptr1 = model1.to_ptr(give_ownership=True)


### PR DESCRIPTION
The added function by default behaves like `addCons()` but takes an iterable (i.e. a list) of constraints. In addition, it supports specifying the same parameters as for `addCons()` - either the same value for all constraints or a list with one value for each constraint.

Also adds a few somewhat elaborate tests for the added `addConss()`. 

A separate commit also fixes some inconsistancies with the existing `addCons()` documentation.

Resolves #507 