### PR TITLE
SCIP 8.0.0

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,7 @@
 name: Integration test
 
 env:
-  version: 7.0.3
+  version: 8.0.0
 
 # runs only on branches; doesn't run on tags.
 on:
@@ -12,7 +12,7 @@ on:
 jobs:
 
   Integration-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies (SCIPOptSuite)
         if: steps.cache-scip.outputs.cache-hit != 'true'
         run: |
-          brew install tbb@2020 boost
+          brew install tbb@2020 boost bison
           wget --quiet --no-check-certificate https://scipopt.org/download/release/scipoptsuite-${{ env.version }}.tgz
           tar xfz scipoptsuite-${{ env.version }}.tgz
           cd scipoptsuite-${{ env.version }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install dependencies (SCIPOptSuite)
         if: steps.cache-scip.outputs.cache-hit != 'true'
         run: |
-          brew install tbb@2020 boost
+          brew install tbb@2020 boost bison
           wget --quiet --no-check-certificate https://scipopt.org/download/release/scipoptsuite-${{ env.version }}.tgz
           tar xfz scipoptsuite-${{ env.version }}.tgz
           cd scipoptsuite-${{ env.version }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,7 +1,7 @@
 name: TestPyPI release
 
 env:
-  version: 7.0.3
+  version: 8.0.0
 
 
 # runs only when a release is published, not on drafts
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-packges-and-generate-documentation:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/update-packages-and-documentation.yml
+++ b/.github/workflows/update-packages-and-documentation.yml
@@ -1,7 +1,7 @@
 name: Test and Release PyPI Package
 
 env:
-  version: 7.0.3
+  version: 8.0.0
 
 
 # runs only when a release is published, not on drafts
@@ -28,7 +28,7 @@ jobs:
 
   release-integration-test:
     needs: check-tag
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:
@@ -100,7 +100,7 @@ jobs:
 
   deploy-packages-and-generate-documentation:
     needs: Windows-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.5.0'
+__version__ = '4.0.0'
 
 # required for Python 3.8 on Windows
 import os

--- a/src/pyscipopt/__init__.py
+++ b/src/pyscipopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.3.0'
+__version__ = '3.5.0'
 
 # required for Python 3.8 on Windows
 import os


### PR DESCRIPTION
I have merged all changes of the ```main``` branch into it and have adapted the integration tests to cope with SCIP 8.0.0.
I have increased the version of pyscipopt to ```3.5.0``` .