### PR TITLE
add activeone param and getSlackVarIndicator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 ### Added
+- added activeone parameter of addConsIndicator() allows to activate the constraint if the binary (indicator) variable is 1 or 0.
+- added function getSlackVarIndicator(), returns the slack variable of the indicator constraint.
 ### Fixed
 ### Changed
 ### Removed

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1657,6 +1657,8 @@ cdef extern from "scip/cons_indicator.h":
                                      SCIP_VAR* var,
                                      SCIP_Real val)
 
+    SCIP_VAR* SCIPgetSlackVarIndicator(SCIP_CONS* cons)
+
 cdef extern from "scip/cons_countsols.h":
     SCIP_RETCODE SCIPcount(SCIP* scip)
     SCIP_RETCODE SCIPsetParamsCountsols(SCIP* scip)
@@ -1727,6 +1729,8 @@ cdef extern from "scip/scip_tree.h":
 
 cdef extern from "scip/scip_var.h":
     SCIP_RETCODE SCIPchgVarBranchPriority(SCIP* scip, SCIP_VAR* var, int branchpriority)
+
+    SCIP_RETCODE SCIPgetNegatedVar(SCIP* scip, SCIP_VAR* var, SCIP_VAR** negvar)
 
 cdef extern from "tpi/tpi.h":
     int SCIPtpiGetNumThreads()


### PR DESCRIPTION
Second try - this pull request implements two features for indicator constraints:

- The `activeone` parameter of `addConsIndicator() `allows to activate the constraint if the binary (indicator) variable is 1 or 0.
- The function `getSlackVarIndicator()` returns the slack variable of the indicator constraint.

