### PR TITLE
CI: Portability tests for building on various Linux distributions and macOS

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,0 +1,105 @@
+name: Run Sage CI for Linux
+
+## This GitHub Actions workflow provides:
+##
+##  - portability testing, by building and testing this project on many platforms
+##    (Linux variants)
+##
+##  - continuous integration, by building and testing other software
+##    that depends on this project.
+##
+## It runs on every push to the GitHub repository.
+##
+## The testing can be monitored in the "Actions" tab of the GitHub repository.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of SageMath (https://www.sagemath.org/).  For more information, see
+## https://doc.sagemath.org/html/en/developer/portability_testing.html
+
+## The workflow consists of two jobs:
+##
+##  - First, it builds a source distribution of the project
+##    and generates a script "update-pkgs.sh".  It uploads them
+##    as a build artifact named upstream.
+##
+##  - Second, it checks out a copy of the SageMath source tree.
+##    It downloads the upstream artifact and replaces the project's
+##    package in the SageMath distribution by the newly packaged one
+##    from the upstream artifact, by running the script "update-pkgs.sh".
+##    Then it builds a small portion of the Sage distribution.
+##
+## Many copies of the second step are run in parallel for each of the tested
+## systems/configurations.
+
+on:
+  pull_request:
+  push:
+    tags:
+    branches:
+      - master
+  workflow_dispatch:
+    # Allow to run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  # Ubuntu packages to install so that the project can build an sdist
+  DIST_PREREQ:      python3-pip
+  # Name of this project in the Sage distribution
+  SPKG:             pyscipopt
+  ## REMOVE_PATCHES:   "*"
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ env.SPKG }}
+        uses: actions/checkout@v2
+        with:
+          path: build/pkgs/${{ env.SPKG }}/src
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
+          python3 -m pip install --user build
+      - name: Run make dist, prepare upstream artifact
+        run: |
+          (cd build/pkgs/${{ env.SPKG }}/src && python3 -m build --sdist .) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/dist/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
+          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
+          && echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh \
+          && echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
+          && ls -l upstream/
+      - uses: actions/upload-artifact@v2
+        with:
+          path: upstream
+          name: upstream
+
+  linux:
+    # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
+    # Use branch u/mkoeppe/numpy_1_23_x__scipy_1_9_x for a fix for uppercase github repo names (FFY00)
+    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@u/mkoeppe/numpy_1_23_x__scipy_1_9_x
+    with:
+      # Sage distribution packages to build
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
+      # Standard setting: Test the current beta release of Sage:
+      sage_repo: sagemath/sage
+      sage_ref: develop
+      upstream_artifact: upstream
+      sage_trac_git: https://github.com/sagemath/sagetrac-mirror.git
+      # Temporarily test on the branch from sage ticket https://trac.sagemath.org/ticket/21003 (pyscipopt)
+      # (this is a no-op after that ticket is merged)
+      sage_trac_ticket: 21003
+      # Docker targets (stages) to tag
+      docker_targets: "with-targets"
+      # We prefix the image name with the SPKG name ("pyscipopt-") to avoid the error
+      # 'Package "sage-docker-..." is already associated with another repository.'
+      docker_push_repository: ghcr.io/${{ github.repository }}/pyscipopt
+    needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -84,7 +84,7 @@ jobs:
 
   linux:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@develop
+    uses: sagemath/sage/.github/workflows/docker.yml@develop
     with:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
@@ -96,10 +96,6 @@ jobs:
       sage_repo: sagemath/sage
       sage_ref: develop
       upstream_artifact: upstream
-      sage_trac_git: https://github.com/sagemath/sagetrac-mirror.git
-      # Temporarily test on the branch from sage ticket https://trac.sagemath.org/ticket/21003 (pyscipopt)
-      # (this is a no-op after that ticket is merged)
-      sage_trac_ticket: 21003
       # Docker targets (stages) to tag
       docker_targets: "with-targets"
       # We prefix the image name with the SPKG name ("pyscipopt-") to avoid the error

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -86,6 +86,10 @@ jobs:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
     uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@develop
     with:
+      # Extra system packages to install. See available packages at
+      # https://github.com/sagemath/sage/tree/develop/build/pkgs
+      # liblzma, bzip2, and libffi are python3 dependencies.
+      extra_sage_packages: "patch cmake liblzma bzip2 libffi python3 onetbb"
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
       # Standard setting: Test the current beta release of Sage:

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -83,7 +83,7 @@ jobs:
 
   linux:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-    uses: sagemath/sage/.github/workflows/docker.yml@develop
+    uses: mkoeppe/sage/.github/workflows/docker.yml@scip_9
     with:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
@@ -93,7 +93,7 @@ jobs:
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
       # Standard setting: Test the current beta release of Sage:
       sage_repo: sagemath/sage
-      sage_ref: develop
+      sage_ref:          refs/pull/37494/head
       upstream_artifact: upstream
       # Docker targets (stages) to tag
       docker_targets: "with-targets"
@@ -103,8 +103,7 @@ jobs:
     needs: [dist]
 
   macos:
-    # Use https://github.com/sagemath/sage/pull/37237
-    uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
+    uses: mkoeppe/sage/.github/workflows/macos.yml@scip_9
     with:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
@@ -113,6 +112,6 @@ jobs:
       # Sage distribution packages to build
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
       sage_repo:         sagemath/sage
-      sage_ref:          refs/pull/37237/head
+      sage_ref:          refs/pull/37494/head
       upstream_artifact: upstream
     needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -35,11 +35,8 @@ name: Run Sage CI for Linux
 ## systems/configurations.
 
 on:
-  pull_request:
   push:
     tags:
-    branches:
-      - master
   workflow_dispatch:
     # Allow to run manually
 

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -84,8 +84,7 @@ jobs:
 
   linux:
     # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-    # Use branch u/mkoeppe/numpy_1_23_x__scipy_1_9_x for a fix for uppercase github repo names (FFY00)
-    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@u/mkoeppe/numpy_1_23_x__scipy_1_9_x
+    uses: sagemath/sagetrac-mirror/.github/workflows/docker.yml@develop
     with:
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,9 +1,9 @@
-name: Run Sage CI for Linux
+name: Run Sage CI for Linux and macOS
 
 ## This GitHub Actions workflow provides:
 ##
 ##  - portability testing, by building and testing this project on many platforms
-##    (Linux variants)
+##    (Linux variants, macOS)
 ##
 ##  - continuous integration, by building and testing other software
 ##    that depends on this project.
@@ -37,6 +37,8 @@ name: Run Sage CI for Linux
 on:
   push:
     tags:
+    branches:
+      - main
   workflow_dispatch:
     # Allow to run manually
 
@@ -57,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out ${{ env.SPKG }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: build/pkgs/${{ env.SPKG }}/src
       - name: Install prerequisites
@@ -74,7 +76,7 @@ jobs:
           && echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh \
           && echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
           && ls -l upstream/
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: upstream
           name: upstream
@@ -86,7 +88,7 @@ jobs:
       # Extra system packages to install. See available packages at
       # https://github.com/sagemath/sage/tree/develop/build/pkgs
       # liblzma, bzip2, and libffi are python3 dependencies.
-      extra_sage_packages: "patch cmake liblzma bzip2 libffi python3 onetbb"
+      extra_sage_packages: "patch cmake gfortran openblas liblzma bzip2 libffi python3 onetbb"
       # Sage distribution packages to build
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
       # Standard setting: Test the current beta release of Sage:
@@ -98,4 +100,14 @@ jobs:
       # We prefix the image name with the SPKG name ("pyscipopt-") to avoid the error
       # 'Package "sage-docker-..." is already associated with another repository.'
       docker_push_repository: ghcr.io/${{ github.repository }}/pyscipopt
+    needs: [dist]
+
+  macos:
+    # Use https://github.com/sagemath/sage/pull/37237
+    uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
+    with:
+      targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
+      sage_repo:         sagemath/sage
+      sage_ref:          refs/pull/37237/head
+      upstream_artifact: upstream
     needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -106,6 +106,11 @@ jobs:
     # Use https://github.com/sagemath/sage/pull/37237
     uses: mkoeppe/sage/.github/workflows/macos.yml@ci-macos-2024
     with:
+      # Extra system packages to install. See available packages at
+      # https://github.com/sagemath/sage/tree/develop/build/pkgs
+      # Use boost_cropped from system because Sage ships 1.66.0, too old for papilo
+      extra_sage_packages: "cmake gfortran openblas boost_cropped onetbb"
+      # Sage distribution packages to build
       targets:           SAGE_CHECK=no SAGE_CHECK_PACKAGES="soplex,scipoptsuite,pyscipopt" pyscipopt
       sage_repo:         sagemath/sage
       sage_ref:          refs/pull/37237/head

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -74,7 +74,7 @@ jobs:
           && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
           && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
           && echo "sed -i.bak \"/pushdef.*LT_VERSION/s/3[0-9.]*/4/\" ../build/pkgs/python3/spkg-configure.m4" >> upstream/update-pkgs.sh \
-          && echo "sed -i.bak \"/export.*proxy/d\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
+          && echo "sed -i.bak \"/export.*proxy/s/export.*/:/\" ../build/bin/sage-spkg" >> upstream/update-pkgs.sh \
           && ls -l upstream/
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,4 +1,4 @@
-name: Run Sage CI for Linux and macOS
+name: Run Sage CI
 
 ## This GitHub Actions workflow provides:
 ##


### PR DESCRIPTION
Using the reusable workflows of the Sage CI. It builds papilo, soplex, scip, pyscipopt from source.

The same is already [in use in SCIP-SDP](https://github.com/scipopt/SCIP-SDP/blob/main/.github/workflows/ci-sage.yml)

Sample run: https://github.com/mkoeppe/PySCIPOpt/actions/runs/7969460775
