### PR TITLE
Add GH Actions workflow to build sdists and wheels, deploy to PyPI

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -9,10 +9,10 @@ on:
     types:
       - published
 
-concurrency:
-  # Cancel previous runs of this workflow for the same branch
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   # Cancel previous runs of this workflow for the same branch
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
 jobs:
   build_wheels:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -9,6 +9,11 @@ on:
     types:
       - published
 
+concurrency:
+  # Cancel previous runs of this workflow for the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -9,10 +9,10 @@ on:
     types:
       - published
 
-# concurrency:
-#   # Cancel previous runs of this workflow for the same branch
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  # Cancel previous runs of this workflow for the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_wheels:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,61 @@
+name: Build and upload to PyPI
+# taken from https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml
+
+on:
+  # Build on every branch push, tag push -- to be disabled later
+  push:
+  # Build when a (published) GitHub Release is created
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.0
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    # if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          #repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -16,13 +16,20 @@ concurrency:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: macos-latest
+            arch: x86_64
+    env:
+      CIBW_ARCHS: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -24,8 +24,6 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
-          - os: ubuntu-latest
-            arch: aarch64
           - os: macos-latest
             arch: x86_64
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,17 @@
 requires = ['setuptools', 'cython <3, >=0.21']
 build-backend = "setuptools.build_meta"
 
-[tool.cibuildwheel.linux]
+[tool.cibuildwheel]
 before-all = [
-  "apt-get update && apt install wget",
-  "wget --quiet --no-check-certificate https://scipopt.org/download/release/SCIPOptSuite-8.0.3-Linux-ubuntu.deb",
-  "apt install -y ./SCIPOptSuite-8.0.3-Linux-ubuntu.deb"
+  "apt-get install --yes git || yum install -y git || brew install git",
+  "git clone --depth=1 https://github.com/sagemath/sage",
+  "cd sage",
+  "make configure",
+  "export PATH=build/bin:$PATH",
+  "eval $(sage-print-system-package-command auto update)",
+  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline)",
+  "./configure --enable-build-as-root",
+  "make -j3 base-toolchain scip"
 ]
+environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/local" }
+build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ before-all = [
   "./configure --enable-build-as-root --enable-fat-binary",
   "make -j3 V=0 base-toolchain scip"
 ]
-environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/local" }
+environment = { PATH="$(pwd)/sage/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/sage/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/sage/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/sage/local" }
 build-frontend = "build"
 # OneTBB, as of version 2021.8.0, does not build on manylinux2014 - https://github.com/oneapi-src/oneTBB/issues/950
 # And manylinux_2_24 is EOL - https://github.com/pypa/manylinux#docker-images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,13 @@ build-frontend = "build"
 # OneTBB, as of version 2021.8.0, does not build on manylinux2014 - https://github.com/oneapi-src/oneTBB/issues/950
 # And manylinux_2_24 is EOL - https://github.com/pypa/manylinux#docker-images
 manylinux-x86_64-image = "manylinux_2_28"
-manylinux-i686-image = "manylinux_2_28"
+# There is no manylinux_2_28 for i686
+
+[tool.cibuildwheel.macos]
+# Build `arm64` wheels on an Intel runner.
+# Note that the `arm64` cannot be tested in this configuration.
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+# On a Linux Intel runner with qemu installed, build Intel and ARM wheels
+archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ['setuptools', 'cython <3, >=0.21']
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel.linux]
+before-all = [
+  "apt-get update && apt install wget",
+  "wget --quiet --no-check-certificate https://scipopt.org/download/release/SCIPOptSuite-8.0.3-Linux-ubuntu.deb",
+  "apt install -y ./SCIPOptSuite-8.0.3-Linux-ubuntu.deb"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ before-all = [
   "make configure",
   "export PATH=build/bin:$PATH",
   "eval $(sage-print-system-package-command auto update)",
-  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp)",
+  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp mpfr boost_cropped onetbb)",
   "./configure --enable-build-as-root --enable-fat-binary",
   "make -j3 V=0 base-toolchain scip"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ before-all = [
   "(apt-get update && apt-get install --yes git) || yum install -y git || brew install git",
   "git clone --depth=1 https://github.com/sagemath/sage",
   "cd sage",
+  "sed -i.bak /tail/s/72/1000/ build/bin/sage-logger",
   "make configure",
   "export PATH=build/bin:$PATH",
   "eval $(sage-print-system-package-command auto update)",
-  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline)",
-  "./configure --enable-build-as-root",
-  "make -j3 base-toolchain scip"
+  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp)",
+  "./configure --enable-build-as-root --enable-fat-binary",
+  "make -j3 V=0 base-toolchain scip"
 ]
 environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/local" }
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ before-all = [
   "make configure",
   "export PATH=build/bin:$PATH",
   "eval $(sage-print-system-package-command auto update)",
-  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp mpfr boost_cropped onetbb)",
+  "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp mpfr boost_cropped onetbb gfortran)",
   "if brew --prefix; then . ./.homebrew-build-env; fi",
   "./configure --enable-build-as-root --enable-fat-binary",
   "make -j3 V=0 base-toolchain scip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ before-all = [
   "export PATH=build/bin:$PATH",
   "eval $(sage-print-system-package-command auto update)",
   "eval $(sage-print-system-package-command auto --yes --no-install-recommends --spkg install cmake zlib ncurses readline patch openblas gmp mpfr boost_cropped onetbb)",
+  "if brew --prefix; then . ./.homebrew-build-env; fi",
   "./configure --enable-build-as-root --enable-fat-binary",
   "make -j3 V=0 base-toolchain scip"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,6 @@ before-all = [
 environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/local" }
 build-frontend = "build"
 # OneTBB, as of version 2021.8.0, does not build on manylinux2014 - https://github.com/oneapi-src/oneTBB/issues/950
-manylinux-x86_64-image = "manylinux_2_24"
-manylinux-i686-image = "manylinux_2_24"
+# And manylinux_2_24 is EOL - https://github.com/pypa/manylinux#docker-images
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ before-all = [
 ]
 environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", ACLOCAL_PATH="/usr/share/aclocal", SCIPOPTDIR="$(pwd)/local" }
 build-frontend = "build"
+# OneTBB, as of version 2021.8.0, does not build on manylinux2014 - https://github.com/oneapi-src/oneTBB/issues/950
+manylinux-x86_64-image = "manylinux_2_24"
+manylinux-i686-image = "manylinux_2_24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,5 @@ build-frontend = "build"
 # And manylinux_2_24 is EOL - https://github.com/pypa/manylinux#docker-images
 manylinux-x86_64-image = "manylinux_2_28"
 # There is no manylinux_2_28 for i686
-
-[tool.cibuildwheel.macos]
-# Build `arm64` wheels on an Intel runner.
-# Note that the `arm64` cannot be tested in this configuration.
-archs = ["x86_64", "arm64"]
-
-[tool.cibuildwheel.linux]
-# On a Linux Intel runner with qemu installed, build Intel and ARM wheels
-archs = ["x86_64", "aarch64"]
+# Until we have alpine - https://github.com/sagemath/sage/issues/33083
+skip = "*-musllinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 before-all = [
-  "apt-get install --yes git || yum install -y git || brew install git",
+  "(apt-get update && apt-get install --yes git) || yum install -y git || brew install git",
   "git clone --depth=1 https://github.com/sagemath/sage",
   "cd sage",
   "make configure",


### PR DESCRIPTION
wheel building via cibuildwheel, using Sage for installing SCIP from source.

Preview: https://github.com/mkoeppe/PySCIPOpt/actions/runs/4220475298

To deploy to PyPI, it will need an Actions secret `PYPI_API_TOKEN`