### PR TITLE
Improve error message when using < or > instead of <= or >=.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add SCIP function SCIPgetSolTime and wrapper getSolTime
 ### Fixed
 ### Changed
+- Improved error message when using < or > instead of <= or >=
 ### Removed
 
 ## 4.3.0 - 2023-03-17

--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -77,7 +77,7 @@ def _expr_richcmp(self, other, op):
         else:
             raise NotImplementedError
     else:
-        raise NotImplementedError
+        raise NotImplementedError("Can only support constraints with '<=', '>=', or '=='.")
 
 
 class Term:


### PR DESCRIPTION
Fixes #634.