### PR TITLE
Update test_branch_probing_lp to avoid failure due to root node solving

### DIFF
--- a/tests/test_branch_probing_lp.py
+++ b/tests/test_branch_probing_lp.py
@@ -45,7 +45,7 @@ def test_branching():
     m.setHeuristics(SCIP_PARAMSETTING.OFF)
     m.setIntParam("presolving/maxrounds", 0)
     #m.setLongintParam("lp/rootiterlim", 3)
-    m.setRealParam("limits/time", 60)
+    m.setLongintParam("limits/nodes", 1)
 
     x0 = m.addVar(lb=-2, ub=4)
     r1 = m.addVar()

--- a/tests/test_branch_probing_lp.py
+++ b/tests/test_branch_probing_lp.py
@@ -1,4 +1,4 @@
-from pyscipopt import Model, Branchrule, SCIP_RESULT, quicksum
+from pyscipopt import Model, Branchrule, SCIP_RESULT, quicksum, SCIP_PARAMSETTING
 
 
 class MyBranching(Branchrule):
@@ -42,6 +42,7 @@ class MyBranching(Branchrule):
 
 def test_branching():
     m = Model()
+    m.setHeuristics(SCIP_PARAMSETTING.OFF)
     m.setIntParam("presolving/maxrounds", 0)
     #m.setLongintParam("lp/rootiterlim", 3)
     m.setRealParam("limits/time", 60)


### PR DESCRIPTION
The test `test_branch_probing_lp.py` fails with SCIP's master branch because it gets solved to optimality in the root node itself. As a workaround, I switched off the heuristics to allow the solution process to enter the branching phase.

It passes fine now on the z1 login node. Do we need to increase the time limit just to be sure of other architectures?

Feel free to suggest alternative changes to fix this failure.