### PR TITLE
Remove warning about SCIP licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 PySCIPOpt
 =========
 
-This project provides an interface from Python to the [SCIP Optimization
-Suite](https://www.scipopt.org/). Please review [SCIP's license restrictions](https://scipopt.org/index.php#license) before installing PySCIPOpt.
+This project provides an interface from Python to the [SCIP Optimization Suite](https://www.scipopt.org/). 
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PySCIPOpt/Lobby)
 [![PySCIPOpt on PyPI](https://img.shields.io/pypi/v/pyscipopt.svg)](https://pypi.python.org/pypi/pyscipopt)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PySCIPOpt
 =========
 
-This project provides an interface from Python to the [SCIP Optimization Suite](https://www.scipopt.org/). 
+This project provides an interface from Python to the [SCIP Optimization Suite](https://www.scipopt.org/). Starting from v8.0.3, SCIP uses the [Apache2.0](https://www.apache.org/licenses/LICENSE-2.0) license. If you plan to use an earlier version of SCIP, please review [SCIP's license restrictions](https://scipopt.org/index.php#license).
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/PySCIPOpt/Lobby)
 [![PySCIPOpt on PyPI](https://img.shields.io/pypi/v/pyscipopt.svg)](https://pypi.python.org/pypi/pyscipopt)


### PR DESCRIPTION
I think this is what @bremner was talking about with #699. Since SCIP is now under the Apache 2.0 license, a warning may not be necessary. 