### PR TITLE
Update Model._modelvars before freeTransfrom

### DIFF
--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1071,9 +1071,12 @@ cdef class Model:
 
     def freeTransform(self):
         """Frees all solution process data including presolving and transformed problem, only original problem is kept"""
+        self._modelvars = {
+            var: value
+            for var, value in self._modelvars.items()
+            if value.isOriginal()
+        }
         PY_SCIP_CALL(SCIPfreeTransform(self._scip))
-        self._modelvars = {}
-        self.getVars()
 
     def version(self):
         """Retrieve SCIP version"""

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1072,6 +1072,8 @@ cdef class Model:
     def freeTransform(self):
         """Frees all solution process data including presolving and transformed problem, only original problem is kept"""
         PY_SCIP_CALL(SCIPfreeTransform(self._scip))
+        self._modelvars = {}
+        self.getVars()
 
     def version(self):
         """Retrieve SCIP version"""

--- a/tests/test_pricer.py
+++ b/tests/test_pricer.py
@@ -158,6 +158,11 @@ def test_cuttingstock():
     assert type(s.getNSols()) == int
     assert s.getNSols() == s.data["nSols"]
 
+    # Testing freeTransform
+    s.freeTransform()
+    for i in range(10):
+        s.addVar()
+
 def test_incomplete_pricer():
     class IncompletePricer(Pricer):
         pass


### PR DESCRIPTION
Before running freeTransform nonOriginal variables are removed from _modelvars.

fix for https://github.com/scipopt/PySCIPOpt/issues/755