### PR TITLE
Revert "Type loop variables"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 ### Added
-- Added types to loop variables
 - Added methods for getting the names of the current stage and of an event
 ### Fixed
 - Fixed outdated time.clock call in gcp.py

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -318,7 +318,6 @@ cdef class Event:
 
     def _getEventNames(self):
         """gets event names"""
-        cdef str name
         for name in dir(PY_SCIP_EVENTTYPE):
             attr = getattr(PY_SCIP_EVENTTYPE, name)
             if isinstance(attr, int):
@@ -508,13 +507,11 @@ cdef class Row:
     def getCols(self):
         """gets list with columns of nonzero entries"""
         cdef SCIP_COL** cols = SCIProwGetCols(self.scip_row)
-        cdef int i
         return [Column.create(cols[i]) for i in range(self.getNNonz())]
 
     def getVals(self):
         """gets list with coefficients of nonzero entries"""
         cdef SCIP_Real* vals = SCIProwGetVals(self.scip_row)
-        cdef int i
         return [vals[i] for i in range(self.getNNonz())]
 
     def getNorm(self):
@@ -553,7 +550,6 @@ cdef class NLRow:
         cdef SCIP_VAR** linvars = SCIPnlrowGetLinearVars(self.scip_nlrow)
         cdef SCIP_Real* lincoefs = SCIPnlrowGetLinearCoefs(self.scip_nlrow)
         cdef int nlinvars = SCIPnlrowGetNLinearVars(self.scip_nlrow)
-        cdef int i
         return [(Variable.create(linvars[i]), lincoefs[i]) for i in range(nlinvars)]
 
     def getLhs(self):
@@ -603,7 +599,6 @@ cdef class Solution:
     def _evaluate(self, term):
         self._checkStage("SCIPgetSolVal")
         result = 1
-        cdef Variable var
         for var in term.vartuple:
             result *= SCIPgetSolVal(self.scip, self.sol, (<Variable> var).scip_var)
         return result
@@ -616,7 +611,6 @@ cdef class Solution:
 
         vals = {}
         self._checkStage("SCIPgetSolVal")
-        cdef int i
         for i in range(SCIPgetNOrigVars(self.scip)):
             scip_var = SCIPgetOrigVars(self.scip)[i]
 
@@ -683,7 +677,6 @@ cdef class DomainChanges:
     def getBoundchgs(self):
         """Returns the bound changes in the domain change."""
         nboundchgs = SCIPdomchgGetNBoundchgs(self.scip_domchg)
-        cdef int i
         return [BoundChange.create(SCIPdomchgGetBoundchg(self.scip_domchg, i))
                 for i in range(nboundchgs)]
 
@@ -731,7 +724,6 @@ cdef class Node:
         cdef int nconss
         SCIPnodeGetAddedConss(self.scip_node, addedconss, &nconss, addedconsssize)
         assert nconss == addedconsssize
-        cdef int i
         constraints = [Constraint.create(addedconss[i]) for i in range(nconss)]
         free(addedconss)
         return constraints
@@ -775,7 +767,6 @@ cdef class Node:
         SCIPnodeGetParentBranchings(self.scip_node, branchvars, branchbounds,
                                     boundtypes, &nbranchvars, nbranchvars)
 
-        cdef int i
         py_variables = [Variable.create(branchvars[i]) for i in range(nbranchvars)]
         py_branchbounds = [branchbounds[i] for i in range(nbranchvars)]
         py_boundtypes = [boundtypes[i] for i in range(nbranchvars)]
@@ -1124,7 +1115,6 @@ cdef class Model:
 
     def freeTransform(self):
         """Frees all solution process data including presolving and transformed problem, only original problem is kept"""
-        cdef unsigned long var
         self._modelvars = {
             var: value
             for var, value in self._modelvars.items()
@@ -1338,20 +1328,17 @@ cdef class Model:
         if coeffs.degree() > 1:
             raise ValueError("Nonlinear objective functions are not supported!")
         
-        cdef int i
         if clear:
             # clear existing objective function
             self.addObjoffset(-self.getObjoffset())
             _vars = SCIPgetOrigVars(self._scip)
             _nvars = SCIPgetNOrigVars(self._scip)
-
             for i in range(_nvars):
                 PY_SCIP_CALL(SCIPchgVarObj(self._scip, _vars[i], 0.0))
 
         if coeffs[CONST] != 0.0:
             self.addObjoffset(coeffs[CONST])
 
-        cdef float coef
         for term, coef in coeffs.terms.items():
             # avoid CONST term of Expr
             if term != CONST:
@@ -1370,7 +1357,6 @@ cdef class Model:
         """Retrieve objective function as Expr"""
         variables = self.getVars()
         objective = Expr()
-        cdef Variable var
         for var in variables:
             coeff = var.getObj()
             if coeff != 0:
@@ -1760,7 +1746,6 @@ cdef class Model:
             _vars = SCIPgetOrigVars(self._scip)
             _nvars = SCIPgetNOrigVars(self._scip)
 
-        cdef int i
         for i in range(_nvars):
             ptr = <size_t>(_vars[i])
 
@@ -1795,8 +1780,6 @@ cdef class Model:
     def getVarDict(self):
         """gets dictionary with variables names as keys and current variable values as items"""
         var_dict = {}
-
-        cdef Variable var
         for var in self.getVars():
             var_dict[var.name] = self.getVal(var)
         return var_dict
@@ -1816,7 +1799,6 @@ cdef class Model:
         if self.getStage() != SCIP_STAGE_PROBLEM:
             raise Warning("method can only be called in stage PROBLEM")
 
-        cdef Variable var
         for var in self.getVars():
             self.chgVarType(var, "C")
 
@@ -1855,7 +1837,6 @@ cdef class Model:
 
         PY_SCIP_CALL(SCIPgetOpenNodesData(self._scip, &_leaves, &_children, &_siblings, &_nleaves, &_nchildren, &_nsiblings))
 
-        cdef int i
         leaves   = [Node.create(_leaves[i]) for i in range(_nleaves)]
         children = [Node.create(_children[i]) for i in range(_nchildren)]
         siblings = [Node.create(_siblings[i]) for i in range(_nsiblings)]
@@ -1895,7 +1876,6 @@ cdef class Model:
         cdef int ncols
 
         PY_SCIP_CALL(SCIPgetLPColsData(self._scip, &cols, &ncols))
-        cdef int i
         return [Column.create(cols[i]) for i in range(ncols)]
 
     def getLPRowsData(self):
@@ -1904,7 +1884,6 @@ cdef class Model:
         cdef int nrows
 
         PY_SCIP_CALL(SCIPgetLPRowsData(self._scip, &rows, &nrows))
-        cdef int i
         return [Row.create(rows[i]) for i in range(nrows)]
 
     def getNLPRows(self):
@@ -1921,7 +1900,6 @@ cdef class Model:
         cdef int* inds = <int *> malloc(nrows * sizeof(int))
 
         PY_SCIP_CALL(SCIPgetLPBasisInd(self._scip, inds))
-        cdef int i
         result = [inds[i] for i in range(nrows)]
         free(inds)
         return result
@@ -1933,7 +1911,6 @@ cdef class Model:
         cdef SCIP_Real* coefs = <SCIP_Real*> malloc(nrows * sizeof(SCIP_Real))
 
         PY_SCIP_CALL(SCIPgetLPBInvRow(self._scip, row, coefs, NULL, NULL))
-        cdef int i
         result = [coefs[i] for i in range(nrows)]
         free(coefs)
         return result
@@ -1945,7 +1922,6 @@ cdef class Model:
         cdef SCIP_Real* coefs = <SCIP_Real*> malloc(ncols * sizeof(SCIP_Real))
 
         PY_SCIP_CALL(SCIPgetLPBInvARow(self._scip, row, NULL, coefs, NULL, NULL))
-        cdef int i
         result = [coefs[i] for i in range(ncols)]
         free(coefs)
         return result
@@ -2186,7 +2162,6 @@ cdef class Model:
         conss = list(conss)
         n_conss = len(conss)
 
-        cdef int idx
         if isinstance(name, str):
             if name == "":
                 name = ["" for idx in range(n_conss)]
@@ -2204,8 +2179,6 @@ cdef class Model:
         stickingatnode = ensure_iterable(stickingatnode, n_conss)
 
         constraints = []
-        cdef int i 
-        cdef ExprCons cons
         for i, cons in enumerate(conss):
             constraints.append(
                 self.addCons(cons, name[i], initial[i], separate[i], enforce[i],
@@ -2248,7 +2221,6 @@ cdef class Model:
         SCIPgetConsVars(self._scip, constraint.scip_cons, _vars, _nvars*sizeof(SCIP_VAR*), &success)
         
         vars = []
-        cdef int i
         for i in range(_nvars):
             ptr = <size_t>(_vars[i])
             # check whether the corresponding variable exists already
@@ -2278,8 +2250,6 @@ cdef class Model:
         vars_array = <SCIP_VAR**> malloc(nvars * sizeof(SCIP_VAR*))
         coeffs_array = <SCIP_Real*> malloc(nvars * sizeof(SCIP_Real))
 
-        cdef int i 
-        cdef float coeff 
         for i, (key, coeff) in enumerate(terms.items()):
             vars_array[i] = <SCIP_VAR*>(<Variable>key[0]).scip_var
             coeffs_array[i] = <SCIP_Real>coeff
@@ -2351,8 +2321,6 @@ cdef class Model:
         terms = cons.expr.terms
 
         # collect variables
-        cdef Variable var
-        cdef int idx 
         variables = {var.ptr():var for term in terms for var in term}
         variables = list(variables.values())
         varindex = {var.ptr():idx for (idx,var) in enumerate(variables)}
@@ -2360,9 +2328,6 @@ cdef class Model:
         # create monomials for terms
         monomials = <SCIP_EXPR**> malloc(len(terms) * sizeof(SCIP_EXPR*))
         termcoefs = <SCIP_Real*> malloc(len(terms) * sizeof(SCIP_Real))
-        cdef int i 
-        cdef int j
-        cdef float coef
         for i, (term, coef) in enumerate(terms.items()):
             termvars = <SCIP_VAR**> malloc(len(term) * sizeof(SCIP_VAR*))
             for j, var in enumerate(term):
@@ -2395,7 +2360,6 @@ cdef class Model:
         PyCons = Constraint.create(scip_cons)
         PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
         PY_SCIP_CALL( SCIPreleaseExpr(self._scip, &expr) )
-
         for i in range(<int>len(terms)):
             PY_SCIP_CALL(SCIPreleaseExpr(self._scip, &monomials[i]))
         free(monomials)
@@ -2428,8 +2392,6 @@ cdef class Model:
 
         varpos = 0
         scipexprs = <SCIP_EXPR**> malloc(len(nodes) * sizeof(SCIP_EXPR*))
-        cdef int i 
-        cdef int c
         for i,node in enumerate(nodes):
             opidx = node[0]
             if opidx == Operator.varidx:
@@ -2518,7 +2480,6 @@ cdef class Model:
         PY_SCIP_CALL(SCIPaddCons(self._scip, scip_cons))
         PyCons = Constraint.create(scip_cons)
         PY_SCIP_CALL(SCIPreleaseCons(self._scip, &scip_cons))
-
         for i in range(len(nodes)):
             PY_SCIP_CALL( SCIPreleaseExpr(self._scip, &scipexprs[i]) )
 
@@ -2591,8 +2552,6 @@ cdef class Model:
         PY_SCIP_CALL(SCIPcreateConsSOS1(self._scip, &scip_cons, str_conversion(name), 0, NULL, NULL,
             initial, separate, enforce, check, propagate, local, dynamic, removable, stickingatnode))
 
-        cdef Variable v
-        cdef int i
         if weights is None:
             for v in vars:
                 var = <Variable>v
@@ -2632,8 +2591,6 @@ cdef class Model:
         PY_SCIP_CALL(SCIPcreateConsSOS2(self._scip, &scip_cons, str_conversion(name), 0, NULL, NULL,
             initial, separate, enforce, check, propagate, local, dynamic, removable, stickingatnode))
 
-        cdef Variable v
-        cdef int i
         if weights is None:
             for v in vars:
                 var = <Variable>v
@@ -2671,8 +2628,6 @@ cdef class Model:
         nvars = len(vars)
 
         _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
-        cdef int idx 
-        cdef Variable var
         for idx, var in enumerate(vars):
             _vars[idx] = (<Variable>var).scip_var
         _resVar = (<Variable>resvar).scip_var
@@ -2712,8 +2667,6 @@ cdef class Model:
         nvars = len(vars)
 
         _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
-        cdef int idx 
-        cdef Variable var
         for idx, var in enumerate(vars):
             _vars[idx] = (<Variable>var).scip_var
         _resVar = (<Variable>resvar).scip_var
@@ -2754,8 +2707,6 @@ cdef class Model:
 
         assert type(rhsvar) is type(bool()), "Provide BOOLEAN value as rhsvar, you gave %s." % type(rhsvar)
         _vars = <SCIP_VAR**> malloc(len(vars) * sizeof(SCIP_VAR*))
-        cdef int idx 
-        cdef Variable var
         for idx, var in enumerate(vars):
             _vars[idx] = (<Variable>var).scip_var
 
@@ -2802,8 +2753,6 @@ cdef class Model:
         if weights is None:
             weights = list(range(1, len(consvars) + 1))
 
-        cdef int i 
-        cdef Variable v
         for i, v in enumerate(consvars):
             var = <Variable>v
             if indvars:
@@ -3171,7 +3120,6 @@ cdef class Model:
         cdef SCIP_NLROW** nlrows
 
         nlrows = SCIPgetNLPNlRows(self._scip)
-        cdef int i
         return [NLRow.create(nlrows[i]) for i in range(self.getNNlRows())]
 
     def getNlRowSolActivity(self, NLRow nlrow, Solution sol = None):
@@ -3261,7 +3209,6 @@ cdef class Model:
         bilinterms = []
         quadterms  = []
 
-        cdef int termidx
         for termidx in range(_nlinvars):
             var = Variable.create(SCIPgetVarExprVar(_linexprs[termidx]))
             linterms.append((var,_lincoefs[termidx]))
@@ -3298,7 +3245,6 @@ cdef class Model:
 
         _conss = SCIPgetConss(self._scip)
         _nconss = SCIPgetNConss(self._scip)
-        cdef int i
         return [Constraint.create(_conss[i]) for i in range(_nconss)]
 
     def getNConss(self):
@@ -3338,7 +3284,6 @@ cdef class Model:
         _vars = SCIPgetVarsLinear(self._scip, cons.scip_cons)
 
         valsdict = {}
-        cdef int i
         for i in range(SCIPgetNVarsLinear(self._scip, cons.scip_cons)):
             valsdict[bytes(SCIPvarGetName(_vars[i])).decode('utf-8')] = _vals[i]
         return valsdict
@@ -3467,8 +3412,6 @@ cdef class Model:
         subprobs = <SCIP**> malloc(nsubproblems * sizeof(SCIP*))
 
         # if subproblems is a dictionary, then the dictionary is turned into a c array
-        cdef int idx 
-        cdef dict subprob
         if isdict:
             for idx, subprob in enumerate(subproblems.values()):
                 subprobs[idx] = (<Model>subprob)._scip
@@ -3503,8 +3446,6 @@ cdef class Model:
         _benders = SCIPgetBenders(self._scip)
 
         # solving all subproblems from all Benders' decompositions
-        cdef int i
-        cdef int j
         for i in range(nbenders):
             nsubproblems = SCIPbendersGetNSubproblems(_benders[i])
             for j in range(nsubproblems):
@@ -3525,8 +3466,6 @@ cdef class Model:
         _benders = SCIPgetBenders(self._scip)
 
         # solving all subproblems from all Benders' decompositions
-        cdef int i
-        cdef int j
         for i in range(nbenders):
             nsubproblems = SCIPbendersGetNSubproblems(_benders[i])
             for j in range(nsubproblems):
@@ -4137,7 +4076,6 @@ cdef class Model:
         PY_SCIP_CALL(SCIPgetLPBranchCands(self._scip, &lpcands, &lpcandssol, &lpcandsfrac,
                                           &nlpcands, &npriolpcands, &nfracimplvars))
 
-        cdef int i
         return ([Variable.create(lpcands[i]) for i in range(nlpcands)], [lpcandssol[i] for i in range(nlpcands)],
                 [lpcandsfrac[i] for i in range(nlpcands)], nlpcands, npriolpcands, nfracimplvars)
 
@@ -4159,7 +4097,6 @@ cdef class Model:
 
         PY_SCIP_CALL(SCIPgetPseudoBranchCands(self._scip, &pseudocands, &npseudocands, &npriopseudocands))
 
-        cdef int i
         return ([Variable.create(pseudocands[i]) for i in range(npseudocands)], npseudocands, npriopseudocands)
 
     def branchVar(self, Variable variable):
@@ -4660,7 +4597,6 @@ cdef class Model:
         nsols = SCIPgetNSols(self._scip)
         sols = []
 
-        cdef int i
         for i in range(nsols):
             sols.append(Solution.create(self._scip, _sols[i]))
 
@@ -4759,7 +4695,6 @@ cdef class Model:
         cdef SCIP_VAR ** _vars = SCIPgetVars(self._scip)
 
         ray = []
-        cdef int i
         for i in range(_nvars):
             ray.append(float(SCIPgetPrimalRayVal(self._scip, _vars[i])))
 
@@ -5086,7 +5021,6 @@ cdef class Model:
 
         params = SCIPgetParams(self._scip)
         result = {}
-        cdef int i
         for i in range(SCIPgetNParams(self._scip)):
           name = SCIPparamGetName(params[i]).decode('utf-8')
           result[name] = self.getParam(name)
@@ -5097,7 +5031,6 @@ cdef class Model:
 
         :param params: dict mapping parameter names to their values.
         """
-        cdef str name
         for name, value in params.items():
           self.setParam(name, value)
 
@@ -5217,7 +5150,6 @@ cdef class Model:
         _nvars = SCIPgetNOrigVars(self._scip)
         _coeffs = <SCIP_Real*> malloc(_nvars * sizeof(SCIP_Real))
 
-        cdef int i
         for i in range(_nvars):
             _coeffs[i] = 0.0
 


### PR DESCRIPTION
Reverts scipopt/PySCIPOpt#758

Explicitly typing variables can lead to errors.

See the following:
![image](https://github.com/scipopt/PySCIPOpt/assets/57299939/299ef4cf-a264-411c-b073-1a311571450a)
![image](https://github.com/scipopt/PySCIPOpt/assets/57299939/93bec97c-f7a5-40d8-b6b0-7bdb16aa4ba5)


The difference is bigger than SCIP's default machine epsilon, so we decided to revert these changes for now. Maybe the best option is to only type our custom types (like Variables, Expressions, etc.), which shouldn't be a problem. We lose the marginal speedup from Cython, but we still get a more robust codebase.