### PR TITLE
Fix dropEvent bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 ### Fixed
+- Fixed "weakly-referenced object no longer exists" when calling dropEvent in test_customizedbenders
 ### Changed
 ### Removed
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -4808,6 +4808,8 @@ cdef class Model:
             _eventhdlr = SCIPfindEventhdlr(self._scip, n)
         else:
             raise Warning("event handler not found")
+        
+        Py_INCREF(self)
         PY_SCIP_CALL(SCIPcatchEvent(self._scip, eventtype, _eventhdlr, NULL, NULL))
 
     def dropEvent(self, eventtype, Eventhdlr eventhdlr):
@@ -4818,6 +4820,8 @@ cdef class Model:
             _eventhdlr = SCIPfindEventhdlr(self._scip, n)
         else:
             raise Warning("event handler not found")
+        
+        Py_DECREF(self)
         PY_SCIP_CALL(SCIPdropEvent(self._scip, eventtype, _eventhdlr, NULL, -1))
 
     def catchVarEvent(self, Variable var, eventtype, Eventhdlr eventhdlr):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -10,8 +10,9 @@ class MyEvent(Eventhdlr):
         calls.append('eventinit')
         self.model.catchEvent(self.event_type, self)        
 
-    #def eventexit(self):
-    #    self.model.dropEvent(self.event_type, self)
+    def eventexit(self):
+        # PR #828 fixes an error here, but the underlying cause might not be solved (self.model being deleted before dropEvent is called)
+        self.model.dropEvent(self.event_type, self)
 
     def eventexec(self, event):
         assert str(event) == event.getName()


### PR DESCRIPTION
It seems to fix the problem with Issue #820, but the underlying cause might still be there. Me and Mo couldn't figure out why ```self.model``` was deleted when the call to ```dropEvent``` is made.

Fix #820.