### PR TITLE
Add SCIPprintExternalCodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- Added SCIPprintExternalCodes (retrieves version of linked symmetry, lp solver, nl solver etc)
 - Added recipe with reformulation for detecting infeasible constraints
 - Wrapped SCIPcreateOrigSol and added tests 
 - Added verbose option for writeProblem and writeParams
@@ -11,7 +12,6 @@
 - Added check for pt_PT locale in test_model.py
 - Added SCIPgetOrigConss and SCIPgetNOrigConss Cython bindings. 
 - Added transformed=False option to getConss, getNConss, and getNVars
-- Added SCIPprintExternalCodes (retrieves version of linked symmetry, lp solver, nl solver etc)
 ### Fixed
 - Fixed locale errors in reading
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added check for pt_PT locale in test_model.py
 - Added SCIPgetOrigConss and SCIPgetNOrigConss Cython bindings. 
 - Added transformed=False option to getConss, getNConss, and getNVars
+- Added SCIPprintExternalCodes (retrieves version of linked symmetry, lp solver, nl solver etc)
 ### Fixed
 - Fixed locale errors in reading
 ### Changed

--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -546,6 +546,7 @@ cdef extern from "scip/scip.h":
     void SCIPsetMessagehdlrLogfile(SCIP* scip, const char* filename)
     SCIP_Real SCIPversion()
     void SCIPprintVersion(SCIP* scip, FILE* outfile)
+    void SCIPprintExternalCodes(SCIP* scip, FILE* outfile)
     SCIP_Real SCIPgetTotalTime(SCIP* scip)
     SCIP_Real SCIPgetSolvingTime(SCIP* scip)
     SCIP_Real SCIPgetReadingTime(SCIP* scip)

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1136,6 +1136,15 @@ cdef class Model:
 
         locale.setlocale(locale.LC_NUMERIC,user_locale)
 
+    def printExternalCodeVersions(self):
+        """Print external code versions, e.g. symmetry, non-linear solver, lp solver"""
+        user_locale = locale.getlocale(category=locale.LC_NUMERIC)
+        locale.setlocale(locale.LC_NUMERIC, "C")
+
+        SCIPprintExternalCodes(self._scip, NULL)
+
+        locale.setlocale(locale.LC_NUMERIC,user_locale)
+
     def getProbName(self):
         """Retrieve problem name"""
         return bytes(SCIPgetProbName(self._scip)).decode('UTF-8')

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -364,3 +364,9 @@ def test_locale():
     m.readProblem(os.path.join("tests", "data", "test_locale.cip"))
 
     locale.setlocale(locale.LC_NUMERIC,"")
+
+
+def test_version_external_codes():
+     scip = Model()
+     scip.printVersion()
+     scip.printExternalCodeVersions()


### PR DESCRIPTION
Adds a wrapper for the SCIP functionality to print external libraries (what you see when you run `./scip` from your terminal at the start.). This lets us easily check that everything is packaged correctly inside of the wheel that we release without checking at the intermediate build stage. (Still should check at the intermediate stage, but it is a way for users to now verify what version of IPOPT / nauty they're now using)