### PR TITLE
fix:solveConcurrent did not work correctly

### DIFF
--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -3563,12 +3563,8 @@ cdef class Model:
     def solveConcurrent(self):
         """Transforms, presolves, and solves problem using additional solvers which emphasize on
         finding solutions."""
-        if SCIPtpiGetNumThreads() == 1:
-            warnings.warn("SCIP was compiled without task processing interface. Parallel solve not possible - using optimize() instead of solveConcurrent()") 
-            self.optimize()
-        else:
-            PY_SCIP_CALL(SCIPsolveConcurrent(self._scip))
-            self._bestSol = Solution.create(self._scip, SCIPgetBestSol(self._scip))
+        PY_SCIP_CALL(SCIPsolveConcurrent(self._scip))
+        self._bestSol = Solution.create(self._scip, SCIPgetBestSol(self._scip))
 
     def presolve(self):
         """Presolve the problem."""


### PR DESCRIPTION
```C
/** returns the number of threads */
int SCIPtpiGetNumThreads(
   void
   )
{
   return _threadpool != NULL ? _threadpool->nthreads : 0;
}
```
In the multi-threaded version of the SCIP with TPI=TNY, the value returned by the SCIPtpiGetNumThreads function does not match the value we expected to set during initialization, but is always 1. This is because the _threadpool value only changes after the SCIPsolveConcurrent function has been called (this is just my current observation, please correct me if there is an error, thank you). Therefore, in the TNY version, using solveConcurrent will always raise the warning 
```cmd
SCIP was compiled without task processing interface. Parallel solve not possible - using optimize() instead of solveConcurrent()
```
instead of correctly invoking the solveConcurrent function in SCIP