### PR TITLE
Change min requirement again

### DIFF
--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -38,8 +38,8 @@ include "nodesel.pxi"
 
 # recommended SCIP version; major version is required
 MAJOR = 9
-MINOR = 1
-PATCH = 0
+MINOR = 0
+PATCH = 1
 
 # for external user functions use def; for functions used only inside the interface (starting with _) use cdef
 # todo: check whether this is currently done like this


### PR DESCRIPTION
SCIP version is returning conflicting information. Update to 9.0.1 requirement (identical to 9.1.0)