### PR TITLE
Change docstring style to numpydocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed too strict getObjVal, getVal check
 ### Changed
 - Changed createSol to now have an option of initialising at the current LP solution
+- Unified documentation style of scip.pxi to numpydocs
 ### Removed
 
 ## 5.1.1 - 2024-06-22

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,79 +1,86 @@
 #############
-API reference
+API Reference
 #############
 
 This page provides an auto-generated summary of PySCIPOpt's API.
 
+.. automodule:: pyscipopt
+
 SCIP Model
 ==========
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This is the main class of PySCIPOpt. Most functionality is accessible through functions
+of this class. All functions that require the SCIP object belong to this class.
 
-  pyscipopt.Model
+.. toctree::
+  :maxdepth: 1
+
+  api/model
 
 SCIP Constraint
 ===============
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP constraint object. It contains functions that can retrieve basic information
+that is entirely contained within the constraint object.
 
-  pyscipopt.Constraint
+.. toctree::
+  :maxdepth: 1
+
+  api/constraint
 
 SCIP Variable
 =============
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP variable object. It contains functions that can retrieve basic information
+that is entirely contained within the variable object.
 
-  pyscipopt.Variable
+.. toctree::
+  :maxdepth: 1
+
+  api/variable
 
 SCIP Row
 ========
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP row object. It contains functions that can retrieve basic information
+that is entirely contained within the row object.
 
-  pyscipopt.scip.Row
+.. toctree::
+  :maxdepth: 1
+
+  api/row
 
 SCIP Column
 ===========
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP column object. It contains functions that can retrieve basic information
+that is entirely contained within the column object.
 
-  pyscipopt.scip.Column
+.. toctree::
+  :maxdepth: 1
+
+  api/column
 
 SCIP Node
 =========
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP node object. It contains functions that can retrieve basic information
+that is entirely contained within the node object.
 
-  pyscipopt.scip.Node
+.. toctree::
+  :maxdepth: 1
 
-SCIP Solution
-=============
-
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
-
-  pyscipopt.scip.Solution
+  api/node
 
 SCIP Event
-===========
+==========
 
-.. autosummary::
-  :toctree: _autosummary
-  :recursive:
+This class wraps a SCIP event object. It contains functions that can retrieve basic information
+that is entirely contained within the event object.
 
-  pyscipopt.scip.Event
+.. toctree::
+  :maxdepth: 1
+
+  api/event
 
 

--- a/docs/api/column.rst
+++ b/docs/api/column.rst
@@ -1,0 +1,6 @@
+##########
+Column API
+##########
+
+.. autoclass:: pyscipopt.scip.Column
+    :members:

--- a/docs/api/constraint.rst
+++ b/docs/api/constraint.rst
@@ -1,0 +1,6 @@
+##############
+Constraint API
+##############
+
+.. autoclass:: pyscipopt.Constraint
+    :members:

--- a/docs/api/event.rst
+++ b/docs/api/event.rst
@@ -1,0 +1,6 @@
+##########
+Event API
+##########
+
+.. autoclass:: pyscipopt.scip.Event
+    :members:

--- a/docs/api/model.rst
+++ b/docs/api/model.rst
@@ -1,0 +1,6 @@
+#########
+Model API
+#########
+
+.. autoclass:: pyscipopt.Model
+    :members:

--- a/docs/api/node.rst
+++ b/docs/api/node.rst
@@ -1,0 +1,6 @@
+########
+Node API
+########
+
+.. autoclass:: pyscipopt.scip.Node
+    :members:

--- a/docs/api/row.rst
+++ b/docs/api/row.rst
@@ -1,0 +1,6 @@
+#######
+Row API
+#######
+
+.. autoclass:: pyscipopt.scip.Row
+    :members:

--- a/docs/api/variable.rst
+++ b/docs/api/variable.rst
@@ -1,0 +1,6 @@
+############
+Variable API
+############
+
+.. autoclass:: pyscipopt.Variable
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,8 +82,9 @@ html_theme = "sphinx_nefertiti"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-autosummary_generate = True
-autoclass_content = "class"
+autosummary_generate = False
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
 
 pygments_style = "sphinx"
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -6486,7 +6486,6 @@ cdef class Model:
         ----------
         probnumber : int
             the problem number for which the target variable belongs, -1 for master problem
-            (default=-1)
         benders : Benders or None, optional
             the Benders' decomposition to which the subproblem variables belong to
 
@@ -6972,7 +6971,7 @@ cdef class Model:
         desc : str
             description of branching rule
         priority : int
-        priority of branching rule
+            priority of branching rule
         maxdepth : int
             maximal depth level up to which this branching rule should be used (or -1)
         maxbounddist : float
@@ -7403,8 +7402,7 @@ cdef class Model:
 
     def solveDiveLP(self, itlim = -1):
         """
-        Solves the LP of the current dive. No separation or pricing is applied
-        no separation or pricing is applied.
+        Solves the LP of the current dive. No separation or pricing is applied.
 
         Parameters
         ----------
@@ -7599,7 +7597,7 @@ cdef class Model:
         cutoff : bool
             whether the probing node can be cutoff
         ndomredsfound : int
-            ndomredsfound -- number of domain reductions found
+            number of domain reductions found
 
         """
         cdef SCIP_Bool cutoff
@@ -8458,7 +8456,7 @@ cdef class Model:
 
     def dropEvent(self, eventtype, Eventhdlr eventhdlr):
         """
-        Drops a global event (stops to track event).
+        Drops a global event (stops tracking the event).
 
         Parameters
         ----------
@@ -8497,7 +8495,7 @@ cdef class Model:
 
     def dropVarEvent(self, Variable var, eventtype, Eventhdlr eventhdlr):
         """
-        Drops an objective value or domain change event (stops to track event) on the given transformed variable.
+        Drops an objective value or domain change event (stops tracking the event) on the given transformed variable.
 
         Parameters
         ----------
@@ -8535,7 +8533,7 @@ cdef class Model:
 
     def dropRowEvent(self, Row row, eventtype, Eventhdlr eventhdlr):
         """
-        Drops a row coefficient, constant, or side change event (stops to track event) on the given row.
+        Drops a row coefficient, constant, or side change event (stops tracking the event) on the given row.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1698,7 +1698,7 @@ cdef class Constraint:
 
     def isLocal(self):
         """
-        Retrieve True if constraint is only locally valid or not added to any (sub)problem.
+        Returns True if constraint is only locally valid or not added to any (sub)problem.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -2625,7 +2625,14 @@ cdef class Model:
         PY_SCIP_CALL(SCIPsetObjlimit(self._scip, objlimit))
 
     def getObjlimit(self):
-        """Returns current limit on objective function."""
+        """
+        Returns current limit on objective function.
+        
+        Returns
+        -------
+        float
+        
+        """
         return SCIPgetObjlimit(self._scip)
 
     def setObjective(self, expr, sense = 'minimize', clear = 'true'):

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1764,7 +1764,7 @@ cdef class Constraint:
 
     def isLinear(self):
         """
-        Retrieve True if constraint is linear
+        Returns True if constraint is linear
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5517,7 +5517,7 @@ cdef class Model:
 
     def getRhs(self, Constraint cons):
         """
-        Retrieve right hand side value of a constraint.
+        Retrieve right-hand side value of a constraint.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1665,7 +1665,7 @@ cdef class Constraint:
 
     def isEnforced(self):
         """
-        Retrieve True if constraint should be enforced during node processing.
+        Returns True if constraint should be enforced during node processing.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -4559,7 +4559,7 @@ cdef class Model:
             should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
         stickingatnode : bool or iterable of bool, optional
             should the constraints always be kept at the node where it was added,
-            even if it may be  @oved to a more global node? (Default value = False)
+            even if it may be moved to a more global node? (Default value = False)
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5493,7 +5493,7 @@ cdef class Model:
 
     def chgLhs(self, Constraint cons, lhs):
         """
-        Change left hand side value of a constraint.
+        Change left-hand side value of a constraint.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -9235,7 +9235,7 @@ cdef class Model:
 
         Returns
         -------
-        int
+        float
 
         """
         return SCIPgetTreesizeEstimation(self._scip)

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -2140,7 +2140,7 @@ cdef class Model:
 
     def getPresolvingTime(self):
         """
-        Retrieve the curernt presolving time in seconds.
+        Returns the current presolving time in seconds.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -3593,7 +3593,7 @@ cdef class Model:
 
     def getNLPCols(self):
         """
-        Retrieve the number of cols currently in the LP.
+        Retrieve the number of columns currently in the LP.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -4488,7 +4488,7 @@ cdef class Model:
             should the relaxation be removed from the LP due to aging or cleanup? (Default value = False)
         stickingatnode : bool, optional
             should the constraints always be kept at the node where it was added,
-            even if it may be  @oved to a more global node? (Default value = False)
+            even if it may be moved to a more global node? (Default value = False)
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -9233,7 +9233,7 @@ cdef class Model:
 
     def getTreesizeEstimation(self):
         """
-        Get an estimation of the final tree size.
+        Get an estimate of the final tree size.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1306,9 +1306,9 @@ cdef class Node:
 
         Returns
         -------
-        py_variables : list of Variable
-        py_branchbounds : list of float
-        py_boundtypes : list of int
+        list of Variable
+        list of float
+        list of int
 
         """
         cdef int nbranchvars = self.getNParentBranchings()
@@ -4460,7 +4460,7 @@ cdef class Model:
         cons : ExprCons
             The expression constraint that is not yet an actual constraint
         name : str, optional
-            the name of the constraint, generic name if empty (Default value = '')
+            the name of the constraint, generic name if empty (Default value = "")
         initial : bool, optional
             should the LP relaxation of constraint be in the initial LP? (Default value = True)
         separate : bool, optional
@@ -4766,8 +4766,6 @@ cdef class Model:
         """
         return PY_SCIP_CALL(SCIPprintCons(self._scip, constraint.scip_cons, NULL))
 
-    # TODO Find a better way to retrieve a scip expression from a python expression. Consider making GenExpr include Expr, to avoid using Union. See PR #760.
-    from typing import Union
     def addExprNonlinear(self, Constraint cons, expr, coef):
         """
         Add coef*expr to nonlinear constraint.
@@ -5046,6 +5044,7 @@ cdef class Model:
             removable=False, stickingatnode=False):
         """
         Add an OR-constraint.
+
         Parameters
         ----------
         vars : list of Variable
@@ -7101,7 +7100,7 @@ cdef class Model:
         Gets branching candidates for LP solution branching (fractional variables) along with solution values,
         fractionalities, and number of branching candidates; The number of branching candidates does NOT account
         for fractional implicit integer variables which should not be used for branching decisions. Fractional
-        implicit integer variables are stored at the positions *nlpcands to *nlpcands + *nfracimplvars - 1
+        implicit integer variables are stored at the positions nlpcands to nlpcands + nfracimplvars - 1
         branching rules should always select the branching candidate among the first npriolpcands of the candidate list
 
         Returns
@@ -8681,7 +8680,7 @@ cdef class Model:
         """
         Set a real-valued parameter.
 
-        :Parameters
+        Parameters
         ----------
         name : str
             name of parameter

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -38,8 +38,8 @@ include "nodesel.pxi"
 
 # recommended SCIP version; major version is required
 MAJOR = 9
-MINOR = 1
-PATCH = 0
+MINOR = 0
+PATCH = 1
 
 # for external user functions use def; for functions used only inside the interface (starting with _) use cdef
 # todo: check whether this is currently done like this

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1687,7 +1687,7 @@ cdef class Constraint:
 
     def isPropagated(self):
         """
-        Retrieve True if constraint should be propagated during node processing.
+        Returns True if constraint should be propagated during node processing.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -6374,7 +6374,7 @@ cdef class Model:
         probnumber : int
             the index of the problem that is to be set up
         solvecip : bool
-            should the CIP of the subproblem be solved, if False, then only the convex relaxation is solved.
+            whether the CIP of the subproblem should be solved. If False, then only the convex relaxation is solved.
         benders : Benders or None, optional
             the Benders' decomposition to which the subproblem belongs to
         solution : Solution or None, optional

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1709,7 +1709,7 @@ cdef class Constraint:
 
     def isModifiable(self):
         """
-        Retrieve True if constraint is modifiable (subject to column generation).
+        Returns True if constraint is modifiable (subject to column generation).
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -3817,7 +3817,7 @@ cdef class Model:
 
     def cacheRowExtensions(self, Row row not None):
         """
-        Informs row, that all subsequent additions of variables to the row
+        Informs row that all subsequent additions of variables to the row
         should be cached and not directly applied;
         after all additions were applied, flushRowExtensions() must be called;
         while the caching of row extensions is activated, information methods of the

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -3313,7 +3313,7 @@ cdef class Model:
 
     def getNIntVars(self):
         """
-        gets number of integer active problem variables.
+        Gets number of integer active problem variables.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1575,7 +1575,7 @@ cdef class Variable(Expr):
 
     def varMayRound(self, direction="down"):
         """
-        Checks whether its it possible to round variable up / down and stay feasible for the relaxation.
+        Checks whether it is possible to round variable up / down and stay feasible for the relaxation.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -9202,7 +9202,7 @@ cdef class Model:
     def getBranchScoreMultiple(self, Variable var, gains):
         """
         Calculates the branching score out of the gain predictions for a branching with
-        arbitrary many children.
+        arbitrarily many children.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5959,7 +5959,7 @@ cdef class Model:
         Parameters
         ----------
         transformed : bool, optional
-            get num. transformed variables instead of original (Default value = True)
+            get number of transformed variables instead of original (Default value = True)
 
         Returns
         -------
@@ -6132,7 +6132,7 @@ cdef class Model:
 
     def getDualSolVal(self, Constraint cons, boundconstraint=False):
         """
-        Retrieve returns dual solution value of a constraint.
+        Returns dual solution value of a constraint.
 
         Parameters
         ----------
@@ -6420,7 +6420,7 @@ cdef class Model:
         probnumber : int
             the problem number for subproblem that is required
         benders : Benders or None, optional
-            the Benders' decomposition object for the that the subproblem belongs to (Default = None)
+            the Benders' decomposition object that the subproblem belongs to (Default = None)
 
         Returns
         -------
@@ -6774,7 +6774,7 @@ cdef class Model:
         name : str
             name of separator
         desc : str
-            description o separator
+            description of separator
         priority : int, optional
             priority of separator (>= 0: before, < 0: after constraint handlers) (default=0)
         freq : int, optional
@@ -6786,7 +6786,7 @@ cdef class Model:
         usessubscip : bool, optional
             does the separator use a secondary SCIP instance? (Default value = False)
         delay : bool, optional
-            should separator be delayed, if other separators found cuts? (Default value = False)
+            should separator be delayed if other separators found cuts? (Default value = False)
 
         """
         n = str_conversion(name)
@@ -7179,7 +7179,7 @@ cdef class Model:
         Node
             Node created for the down (left) branch
         Node or None
-            Node created for the equal child (middle child). Only exists of branch variable is integer
+            Node created for the equal child (middle child). Only exists if branch variable is integer
         Node
             Node created for the up (right) branch
 
@@ -7208,7 +7208,7 @@ cdef class Model:
         Node
             Node created for the down (left) branch
         Node or None
-            Node created for the equal child (middle child). Only exists of branch variable is integer
+            Node created for the equal child (middle child). Only exists if the branch variable is integer
         Node
             Node created for the up (right) branch
 
@@ -7274,7 +7274,7 @@ cdef class Model:
         nodeselprio : int
             node selection priority of new node
         estimate : float
-            estimate for(transformed) objective value of best feasible solution in subtree
+            estimate for (transformed) objective value of best feasible solution in subtree
 
         Returns
         -------
@@ -7380,7 +7380,7 @@ cdef class Model:
     def chgRowRhsDive(self, Row row, newrhs):
         """
         Changes row rhs in current dive, change will be undone after diving
-        ends, for permanent changes use SCIPchgRowLhs().
+        ends. For permanent changes use SCIPchgRowRhs().
 
         Parameters
         ----------
@@ -7403,18 +7403,18 @@ cdef class Model:
 
     def solveDiveLP(self, itlim = -1):
         """
-        Solves the LP of the current dive no separation or pricing is applied
+        Solves the LP of the current dive. No separation or pricing is applied
         no separation or pricing is applied.
 
         Parameters
         ----------
-        itlim : it, optional
+        itlim : int, optional
             maximal number of LP iterations to perform (Default value = -1, that is, no limit)
 
         Returns
         -------
         lperror : bool
-            if an unresolved lp error occured
+            whether an unresolved lp error occured
         cutoff : bool
             whether the LP was infeasible or the objective limit was reached
 
@@ -7950,9 +7950,9 @@ cdef class Model:
         checkbounds : bool, optional
             should the bounds of the variables be checked? (Default value = True)
         checkintegrality : bool, optional
-            has integrality to be checked? (Default value = True)
+            does integrality have to be checked? (Default value = True)
         checklprows : bool, optional
-            have current LP rows (both local and global) to be checked? (Default value = True)
+            do current LP rows (both local and global) have to be checked? (Default value = True)
         free : bool, optional
             should solution be freed? (Default value = True)
 
@@ -8147,7 +8147,7 @@ cdef class Model:
 
     def getSolTime(self, Solution sol):
         """
-        Get clock time, when this solution was found.
+        Get clock time when this solution was found.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -479,7 +479,7 @@ cdef class Column:
 
         Notes
         -----
-        Returns basis status `zero` for columns not in the current SCIP LP.
+        Returns basis status "zero" for columns not in the current SCIP LP.
 
         """
         cdef SCIP_BASESTAT stat = SCIPcolGetBasisStatus(self.scip_col)
@@ -670,7 +670,7 @@ cdef class Row:
 
         Notes
         -----
-        Returns basis status `basic` for rows not in the current SCIP LP.
+        Returns basis status "basic" for rows not in the current SCIP LP.
 
         """
         cdef SCIP_BASESTAT stat = SCIProwGetBasisStatus(self.scip_row)
@@ -4520,9 +4520,9 @@ cdef class Model:
 
         Each of the constraints is added to the model using Model.addCons().
 
-        For all parameters, except @p conss, this method behaves differently depending on the
+        For all parameters, except `conss`, this method behaves differently depending on the
         type of the passed argument:
-        1. If the value is iterable, it must be of the same length as @p conss. For each
+        1. If the value is iterable, it must be of the same length as `conss`. For each
         constraint, Model.addCons() will be called with the value at the corresponding index.
         2. Else, the (default) value will be applied to all of the constraints.
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1731,7 +1731,7 @@ cdef class Constraint:
 
     def isRemovable(self):
         """
-        Retrieve True if constraint's relaxation should be removed from the LP due to aging or cleanup.
+        Returns True if constraint's relaxation should be removed from the LP due to aging or cleanup.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1654,7 +1654,7 @@ cdef class Constraint:
 
     def isSeparated(self):
         """
-        Retrieve True if constraint should be separated during LP processing.
+        Returns True if constraint should be separated during LP processing.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5985,7 +5985,7 @@ cdef class Model:
 
     def delConsLocal(self, Constraint cons):
         """
-        Delete constraint from the current node and it's children.
+        Delete constraint from the current node and its children.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -2151,7 +2151,7 @@ cdef class Model:
 
     def getNLPIterations(self):
         """
-        Retrieve the total number of LP iterations so far.
+        Returns the total number of LP iterations so far.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1643,7 +1643,7 @@ cdef class Constraint:
 
     def isInitial(self):
         """
-        Retrieve True if the relaxation of the constraint should be in the initial LP.
+        Returns True if the relaxation of the constraint should be in the initial LP.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1720,7 +1720,7 @@ cdef class Constraint:
 
     def isDynamic(self):
         """
-        Retrieve True if constraint is subject to aging.
+        Returns True if constraint is subject to aging.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5476,7 +5476,7 @@ cdef class Model:
         cons : Constraint
             linear or quadratic constraint
         rhs : float or None
-            new right hand side (set to None for +infinity)
+            new right-hand side (set to None for +infinity)
 
         """
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1776,7 +1776,7 @@ cdef class Constraint:
 
     def isNonlinear(self):
         """
-        Retrieve True if constraint is nonlinear.
+        Returns True if constraint is nonlinear.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -7289,7 +7289,7 @@ cdef class Model:
     def startDive(self):
         """Initiates LP diving.
         It allows the user to change the LP in several ways, solve, change again, etc,
-        without affecting the actual LP that has. When endDive() is called,
+        without affecting the actual LP. When endDive() is called,
         SCIP will undo all changes done and recover the LP it had before startDive."""
         PY_SCIP_CALL(SCIPstartDive(self._scip))
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1676,7 +1676,7 @@ cdef class Constraint:
 
     def isChecked(self):
         """
-        Retrieve True if constraint should be checked for feasibility.
+        Returns True if constraint should be checked for feasibility.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -9154,7 +9154,7 @@ cdef class Model:
         upconflict : bool
             store whether a conflict constraint was created for an infeasible upwards branch
         lperror : bool
-            whether an unresolved LP error occurred or the solving process
+            whether an unresolved LP error occurred in the solving process
 
         """
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5469,7 +5469,7 @@ cdef class Model:
 
     def chgRhs(self, Constraint cons, rhs):
         """
-        Change right hand side value of a constraint.
+        Change right-hand side value of a constraint.
 
         Parameters
         ----------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1742,7 +1742,7 @@ cdef class Constraint:
 
     def isStickingAtNode(self):
         """
-        Retrieve True if constraint is only locally valid or not added to any (sub)problem.
+        Returns True if constraint is only locally valid or not added to any (sub)problem.
 
         Returns
         -------

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5500,7 +5500,7 @@ cdef class Model:
         cons : Constraint
             linear or quadratic constraint
         lhs : float or None
-            new left hand side (set to None for -infinity)
+            new left-hand side (set to None for -infinity)
 
         """
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -9280,7 +9280,7 @@ cdef class Model:
         edge_features : list of list
         row_features : list of list
         dict
-            The feature mappings for the cols, edges, and rows
+            The feature mappings for the columns, edges, and rows
 
         """
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5539,7 +5539,7 @@ cdef class Model:
 
     def getLhs(self, Constraint cons):
         """
-        Retrieve left hand side value of a constraint.
+        Retrieve left-hand side value of a constraint.
 
         Parameters
         ----------


### PR DESCRIPTION
What was done in this MR:
- Unified docstring style to numpydoc
- Added missing information on parameters to docstring where appropriate
- Add new style of showing the API to the online documentation.

What I did not do:
- Change the docstrings of all tests + other pieces of code. I think much of this will come from implementing a style formatter.
- I did not add type hints. If anything I removed the few that we had. Guides online suggest that they are redundant if the docstrings are done properly. IDEs should now be able to extract the types for all parameters for instance. Implementing type hints in Cython is also different than standard Python. For instance, mypy requires an additional file with each function declaration. 