### PR TITLE
Generic indicator names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added stage checks to presolve, freereoptsolve, freetransform
 - Added primal_dual_evolution recipe and a plot recipe
 ### Fixed
+- Added default names to indicator constraints
 ### Changed
 - GitHub actions using Mac now use precompiled SCIP from latest release
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added stage checks to presolve, freereoptsolve, freetransform
 - Added primal_dual_evolution recipe and a plot recipe
 ### Fixed
+- Fixed default name for indicator constraints
 ### Changed
 ### Removed
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -5330,7 +5330,7 @@ cdef class Model:
 
         return pyCons
 
-    def addConsIndicator(self, cons, binvar=None, activeone=True, name="IndicatorCons",
+    def addConsIndicator(self, cons, binvar=None, activeone=True, name="",
                 initial=True, separate=True, enforce=True, check=True,
                 propagate=True, local=False, dynamic=False,
                 removable=False, stickingatnode=False):
@@ -5348,7 +5348,7 @@ cdef class Model:
         activeone : bool, optional
             constraint should active if binvar is 1 (0 if activeone = False)
         name : str, optional
-            name of the constraint (Default value = "IndicatorCons")
+            name of the constraint (Default value = "")
         initial : bool, optional
             should the LP relaxation of constraint be in the initial LP? (Default value = True)
         separate : bool, optional
@@ -5380,6 +5380,9 @@ cdef class Model:
         cdef SCIP_VAR* _binVar
         if cons._lhs is not None and cons._rhs is not None:
             raise ValueError("expected inequality that has either only a left or right hand side")
+
+        if name == '':
+            name = 'c'+str(SCIPgetNConss(self._scip)+1)
 
         if cons.expr.degree() > 1:
             raise ValueError("expected linear inequality, expression has degree %d" % cons.expr.degree())

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -101,20 +101,33 @@ def test_SOScons():
 
 def test_cons_indicator():
     m = Model()
-    x = m.addVar(lb=0)
+    x = m.addVar(lb=0, obj=1)
     binvar = m.addVar(vtype="B", lb=1)
 
-    c = m.addConsIndicator(x >= 1, binvar)
+    c1 = m.addConsIndicator(x >= 1, binvar) 
 
-    slack = m.getSlackVarIndicator(c)
+    assert c1.name == "c1"
+
+    c2 = m.addCons(x <= 3)
+
+    c3 = m.addConsIndicator(x >= 0, binvar)
+    assert c3.name == "c4"
+
+    # because addConsIndicator actually adds two constraints
+    assert m.getNConss() == 5
+
+    slack = m.getSlackVarIndicator(c1)
 
     m.optimize()
 
+    assert m.getNConss() == 5
     assert m.isEQ(m.getVal(slack), 0)
     assert m.isEQ(m.getVal(binvar), 1)
     assert m.isEQ(m.getVal(x), 1)
-    assert c.getConshdlrName() == "indicator"
+    assert c1.getConshdlrName() == "indicator"
 
+
+test_cons_indicator()
 
 @pytest.mark.xfail(
     reason="addConsIndicator doesn't behave as expected when binary variable is False. See Issue #717."

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -120,7 +120,7 @@ def test_cons_indicator():
 
     m.optimize()
 
-    assert m.getNConss() == 5
+    assert m.getNConss(transformed=False) == 5
     assert m.isEQ(m.getVal(slack), 0)
     assert m.isEQ(m.getVal(binvar), 1)
     assert m.isEQ(m.getVal(x), 1)

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -126,9 +126,6 @@ def test_cons_indicator():
     assert m.isEQ(m.getVal(x), 1)
     assert c1.getConshdlrName() == "indicator"
 
-
-test_cons_indicator()
-
 @pytest.mark.xfail(
     reason="addConsIndicator doesn't behave as expected when binary variable is False. See Issue #717."
 )


### PR DESCRIPTION
Indicator constraints all had the same name by default. They now have the same default naming convention as other constraints. 

I did discover a big bug that I'll fix later. When a model has indicator constraints and is optimized, all the constraints disappear. Not good. The tests are failing because of the assertion I added detecting this. EDIT: I'm very dumb, by default `getNConss` returns the number of constraints of the transformed problem.