### PR TITLE
Add transformed option to getVarDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Added
+- Added transformed option to getVarDict, updated test
 - Added categorical data example
 - Added printProblem to print problem to stdout
 - Added stage checks to presolve, freereoptsolve, freetransform

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -3458,9 +3458,14 @@ cdef class Model:
         """
         return SCIPgetNContVars(self._scip)
     
-    def getVarDict(self):
+    def getVarDict(self, transformed=False):
         """
         Gets dictionary with variables names as keys and current variable values as items.
+
+        Parameters
+        ----------
+        transformed : bool, optional
+            Get transformed variables instead of original (Default value = False)
 
         Returns
         -------
@@ -3468,7 +3473,7 @@ cdef class Model:
 
         """
         var_dict = {}
-        for var in self.getVars():
+        for var in self.getVars(transformed=transformed):
             var_dict[var.name] = self.getVal(var)
         return var_dict
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -244,14 +244,21 @@ def test_getVarsDict():
     x = {}
     for i in range(5):
         x[i] = model.addVar(lb = -i, ub = i, vtype="C")
-    for i in range(10,15):
+    for i in range(5,10):
         x[i] = model.addVar(lb = -i, ub = i, vtype="I")
-    for i in range(20,25):
+    for i in range(10,15):
         x[i] = model.addVar(vtype="B")
+
+    model.addConsIndicator(x[0] <= 4, x[10])
     
+    model.setPresolve(0)
     model.hideOutput()
     model.optimize()
     var_dict = model.getVarDict()
+    var_dict_transformed = model.getVarDict(transformed=True)
+    assert len(var_dict) == model.getNVars(transformed=False)
+    assert len(var_dict_transformed) == model.getNVars(transformed=True)
+
     for v in x.values():
         assert v.name in var_dict
         assert model.getVal(v) == var_dict[v.name]


### PR DESCRIPTION
Allows `getVarDict` to be used on the transformed problem.

I don't know which should be the default value for the `transformed` flag, as this doesn't seem consistent in the rest of the source code. `getVars`, `getObjVal`, `getSolObjVal` default to original the original problem, `getConss`, `getNConss`, `getNVars` to the transformed problem. I don't know if we should change them, though, because it would have big consequences.