### PR TITLE
Fixed bug when accessing matrix variable attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added SCIP_LPPARAM, setIntParam, setRealParam, getIntParam, getRealParam, isOptimal, getObjVal, getRedcost for lpi
 - Added isFeasPositive
 ### Fixed
+- Fixed bug when accessing matrix variable attributes
 ### Changed
 ### Removed
 

--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -1685,7 +1685,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         vtypes = np.empty(self.shape, dtype=object)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             vtypes[idx] = self[idx].vtype()
         return vtypes
 
@@ -1700,7 +1700,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         in_lp = np.empty(self.shape, dtype=bool)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             in_lp[idx] = self[idx].isInLP()
         return in_lp
 
@@ -1715,7 +1715,7 @@ class MatrixVariable(MatrixExpr):
             An array of integers. No two should be the same
         """
         indices = np.empty(self.shape, dtype=int)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             indices[idx] = self[idx].getIndex()
         return indices
 
@@ -1730,7 +1730,7 @@ class MatrixVariable(MatrixExpr):
         """
 
         columns = np.empty(self.shape, dtype=object)
-        for idx in np.index(self):
+        for idx in np.ndindex(self.shape):
             columns[idx] = self[idx].getCol()
         return columns
 
@@ -1744,7 +1744,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         lbs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             lbs[idx] = self[idx].getLbOriginal()
         return lbs
 
@@ -1758,7 +1758,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         ubs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             ubs[idx] = self[idx].getUbOriginal()
         return ubs
 
@@ -1772,7 +1772,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         lbs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             lbs[idx] = self[idx].getLbGlobal()
         return lbs
 
@@ -1786,7 +1786,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         ubs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             ubs[idx] = self[idx].getUbGlobal()
         return ubs
 
@@ -1800,7 +1800,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         lbs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             lbs[idx] = self[idx].getLbLocal()
         return lbs
 
@@ -1814,7 +1814,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         ubs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             ubs[idx] = self[idx].getUbLocal()
         return ubs
 
@@ -1828,7 +1828,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         objs = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             objs[idx] = self[idx].getObj()
         return objs
 
@@ -1842,7 +1842,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         lpsols = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             lpsols[idx] = self[idx].getLPSol()
         return lpsols
 
@@ -1856,7 +1856,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         avgsols = np.empty(self.shape, dtype=float)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             avgsols[idx] = self[idx].getAvgSol()
         return avgsols
 
@@ -1876,7 +1876,7 @@ class MatrixVariable(MatrixExpr):
 
         """
         mayround = np.empty(self.shape, dtype=bool)
-        for idx in np.ndindex(self):
+        for idx in np.ndindex(self.shape):
             mayround[idx] = self[idx].varMayRound()
         return mayround
 

--- a/tests/test_matrix_variable.py
+++ b/tests/test_matrix_variable.py
@@ -294,6 +294,26 @@ def test_documentation():
     assert (isinstance(cons, MatrixExprCons))
     assert (isinstance(cons[0][0], ExprCons))
 
+def test_MatrixVariable_attributes():
+    m = Model()
+    x = m.addMatrixVar(shape=(2,2), vtype='C', name='x', ub=np.array([[5, 6], [2, 8]]), obj=1)
+    assert x.vtype().tolist() == [['CONTINUOUS', 'CONTINUOUS'], ['CONTINUOUS', 'CONTINUOUS']]
+    assert x.isInLP().tolist() == [[False, False], [False, False]]
+    assert x.getIndex().tolist() == [[0, 1], [2, 3]]
+    #assert x.getCol().tolist()# == [[5, 6], [2, 8]]
+    assert x.getLbGlobal().tolist() == [[0, 0], [0, 0]]
+    assert x.getUbGlobal().tolist() == [[5, 6], [2, 8]]
+    assert x.getObj().tolist() == [[1, 1], [1, 1]]
+    m.setMaximize()
+    m.optimize()
+    assert x.getUbLocal().tolist() == [[5, 6], [2, 8]]
+    assert x.getLbLocal().tolist() == [[5, 6], [2, 8]]
+    assert x.getLPSol().tolist() == [[5, 6], [2, 8]]
+    assert x.getAvgSol().tolist() == [[5, 6], [2, 8]]
+    assert x.varMayRound().tolist() == [[True, True], [True, True]]
+
+
+test_MatrixVariable_attributes()
 
 @pytest.mark.skip(reason="Performance test")
 def test_performance():

--- a/tests/test_matrix_variable.py
+++ b/tests/test_matrix_variable.py
@@ -300,7 +300,6 @@ def test_MatrixVariable_attributes():
     assert x.vtype().tolist() == [['CONTINUOUS', 'CONTINUOUS'], ['CONTINUOUS', 'CONTINUOUS']]
     assert x.isInLP().tolist() == [[False, False], [False, False]]
     assert x.getIndex().tolist() == [[0, 1], [2, 3]]
-    #assert x.getCol().tolist()# == [[5, 6], [2, 8]]
     assert x.getLbGlobal().tolist() == [[0, 0], [0, 0]]
     assert x.getUbGlobal().tolist() == [[5, 6], [2, 8]]
     assert x.getObj().tolist() == [[1, 1], [1, 1]]

--- a/tests/test_matrix_variable.py
+++ b/tests/test_matrix_variable.py
@@ -312,9 +312,6 @@ def test_MatrixVariable_attributes():
     assert x.getAvgSol().tolist() == [[5, 6], [2, 8]]
     assert x.varMayRound().tolist() == [[True, True], [True, True]]
 
-
-test_MatrixVariable_attributes()
-
 @pytest.mark.skip(reason="Performance test")
 def test_performance():
     start_orig = time()


### PR DESCRIPTION
Fix #969 

There's still a bug with `getCol`, but that one is also a bug in the normal variables. I'm thinking it may just be about adding an assertion.

@DominikKamp do you know when `SCIPvarGetCol` returns NULL?