### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             arch: x86_64
           - os: macos-14
             arch: arm64
@@ -55,7 +55,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -71,14 +71,14 @@ jobs:
   merge_artifacts:
     name: Merge Artifacts
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v4
 
   upload_pypi:
     needs: [build_wheels, build_sdist, merge_artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.inputs.upload_to_pypi == 'true'
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: x86_64
           - os: macos-14
             arch: arm64

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   test-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   test-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   Integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   Integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-packges-and-generate-documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-packges-and-generate-documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/update-packages-and-documentation.yml
+++ b/.github/workflows/update-packages-and-documentation.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   check-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: check tag ${{ github.ref }}
         run: |
@@ -28,7 +28,7 @@ jobs:
 
   release-integration-test:
     needs: check-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -100,7 +100,7 @@ jobs:
 
   deploy-packages-and-generate-documentation:
     needs: Windows-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/update-packages-and-documentation.yml
+++ b/.github/workflows/update-packages-and-documentation.yml
@@ -28,7 +28,7 @@ jobs:
 
   release-integration-test:
     needs: check-tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -100,7 +100,7 @@ jobs:
 
   deploy-packages-and-generate-documentation:
     needs: Windows-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
See [The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15 ](https://github.com/actions/runner-images/issues/11101)