### PR TITLE
Add support for indicator constraints

### DIFF
--- a/src/pyscipopt/scip.pxd
+++ b/src/pyscipopt/scip.pxd
@@ -1851,14 +1851,40 @@ cdef extern from "scip/cons_indicator.h":
                                          SCIP_Bool dynamic,
                                          SCIP_Bool removable,
                                          SCIP_Bool stickingatnode)
-
     SCIP_RETCODE SCIPaddVarIndicator(SCIP* scip,
                                      SCIP_CONS* cons,
                                      SCIP_VAR* var,
                                      SCIP_Real val)
-
-    SCIP_VAR* SCIPgetSlackVarIndicator(SCIP_CONS* cons)
     SCIP_CONS* SCIPgetLinearConsIndicator(SCIP_CONS* cons)
+    SCIP_RETCODE SCIPsetLinearConsIndicator(SCIP* scip,
+                                            SCIP_CONS* cons,
+                                            SCIP_CONS* lincons)
+    SCIP_RETCODE SCIPsetBinaryVarIndicator(SCIP* scip,
+                                            SCIP_CONS* cons,
+                                            SCIP_VAR* binvar)
+    SCIP_RETCODE SCIPgetActiveOneIndicator(SCIP_Cons* cons,
+                                           SCIP_VAR* binvar)
+    SCIP_VAR* SCIPgetBinaryVarIndicator(SCIP_CONS* cons)
+    SCIP_VAR* SCIPgetSlackVarIndicator(SCIP_CONS* cons)
+    SCIP_RETCODE SCIPsetSlackVarIndicator(SCIP* scip,
+                                          SCIP_CONS* cons,
+                                          SCIP_VAR* slackvar)
+    SCIP_Bool SCIPisActiveOneIndicator(SCIP* scip,
+                                       SCIP_CONS* cons,
+                                       SCIP_VAR* binvar)
+    SCIP_Bool SCIPmakeIndicatorFeasible(SCIP* scip,
+                                       SCIP_CONS* cons,
+                                       SCIP_SOL* sol,
+                                       SCIP_Bool* changed)
+    SCIP_Bool SCIPmakeIndicatorsFeasible(SCIP* scip,
+                                         SCIP_CONSHDLR* conshdlr,
+                                         SCIP_SOL* sol)
+    SCIP_RETCODE SCIPaddLinearConsIndicator(SCIP* scip,
+                                            SCIP_CONSHDLR* conshdlr,
+                                            SCIP_CONS* cons)
+    SCIP_RETCODE SCIPaddRowIndicator(SCIP* scip,
+                                     SCIP_CONSHDLR* conshdlr,
+                                     SCIP_ROW* row)
 
 cdef extern from "scip/misc.h":
     SCIP_RETCODE SCIPhashmapCreate(SCIP_HASHMAP** hashmap, BMS_BLKMEM* blkmem, int mapsize)

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -104,7 +104,7 @@ def test_cons_indicator():
     x = m.addVar(lb=0, obj=1)
     binvar = m.addVar(vtype="B", lb=1)
 
-    c1 = m.addConsIndicator(x >= 1, binvar) 
+    c1 = m.addConsIndicator(x >= 1, binvar)
 
     assert c1.name == "c1"
 


### PR DESCRIPTION
Missing tests and a bunch of `create/add generic indicator etc.` methods.

Didn't try to compile. Also, should we interface things like `setLinearConsIndicator`, `setBinaryVarIndicator`, when things are done automatically when we call `addConsIndicator`?