### PR TITLE
.github/workflows/build_wheels.yml: Build aarch64 wheels on ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,6 +24,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04


### PR DESCRIPTION
Depends on
- https://github.com/scipopt/scipoptsuite-deploy/pull/25