### PR TITLE
Documentation Suggestions for build.rst and lp.pxi

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ If installing SCIP from source or using PyPI with a python and operating system 
 you need to specify the install location using the environment variable
 `SCIPOPTDIR`:
 
--   on Linux and OS X:\
+-   on Linux and MacOS:\
     `export SCIPOPTDIR=<path_to_install_dir>`
 -   on Windows:\
     `set SCIPOPTDIR=<path_to_install_dir>` (**cmd**, **Cmder**, **WSL**)\
@@ -45,8 +45,9 @@ contains the corresponding header files:
         > nlpi
         > ...
 
-Please note that some Mac configurations require adding the library installation path to `DYLD_LIBRARY_PATH` when using a locally installed version of SCIP.
+On MacOS, to ensure that the SCIP dynamic library can be located at runtime by PySCIPOpt, you should add your SCIP installation path to the ``DYLD_LIBRARY_PATH`` environment variable by running:
 
+`export DYLD_LIBRARY_PATH="<path_to_install_dir>/lib:$DYLD_LIBRARY_PATH"`
 
 When building SCIP from source using Windows it is highly recommended to use the [Anaconda Python
 Platform](https://www.anaconda.com/).
@@ -75,7 +76,7 @@ at runtime by adjusting your `PATH` environment variable:
 
 -   on Windows: `set PATH=%PATH%;%SCIPOPTDIR%\bin`
 
-On Linux and OS X this is encoded in the generated PySCIPOpt library and
+On Linux and MacOS this is encoded in the generated PySCIPOpt library and
 therefore not necessary.
 
 Building everything from source

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -100,6 +100,15 @@ For Linux and MacOS systems set the variable with the following command:
 
   export SCIPOPTDIR=<path_to_install_dir>
 
+.. note::
+
+  For macOS users, to ensure that the SCIP dynamic library can be found at runtime by PySCIPOpt,
+  you should add your SCIP installation path to the ``DYLD_LIBRARY_PATH`` environment variable by running:
+
+  .. code-block::
+
+    export DYLD_LIBRARY_PATH="<path_to_install_dir>/lib:$DYLD_LIBRARY_PATH"
+
 For Windows use the following command:
 
 .. code-block:: bash

--- a/src/pyscipopt/lp.pxi
+++ b/src/pyscipopt/lp.pxi
@@ -58,7 +58,8 @@ cdef class LP:
         """Adds a single column to the LP.
 
         Keyword arguments:
-        entries -- list of tuples, each tuple consists of a row index and a coefficient
+        entries -- a list of tuples; if p is the index of the new column, then each tuple (i, k) indicates that
+        A[i][p] = k, where A is the constraint matrix and k is a nonzero entry.
         obj     -- objective coefficient (default 0.0)
         lb      -- lower bound (default 0.0)
         ub      -- upper bound (default infinity)
@@ -85,7 +86,8 @@ cdef class LP:
         """Adds multiple columns to the LP.
 
         Keyword arguments:
-        entrieslist -- list containing lists of tuples, each tuple contains a coefficient and a row index
+        entrieslist -- a list of lists, where the j-th inner list contains tuples (i, k) such that A[i][p] = k,
+        where A is the constraint matrix, p is the index of the j-th new column, and k is a nonzero entry.
         objs  -- objective coefficient (default 0.0)
         lbs   -- lower bounds (default 0.0)
         ubs   -- upper bounds (default infinity)
@@ -147,7 +149,8 @@ cdef class LP:
         """Adds a single row to the LP.
 
         Keyword arguments:
-        entries -- list of tuples, each tuple contains a coefficient and a column index
+        entries -- a list of tuples; if q is the index of the new row, then each tuple (j, k) indicates that
+        A[q][j] = k, where A is the constraint matrix and k is a nonzero entry.
         lhs     -- left-hand side of the row (default 0.0)
         rhs     -- right-hand side of the row (default infinity)
         """
@@ -172,7 +175,8 @@ cdef class LP:
         """Adds multiple rows to the LP.
 
         Keyword arguments:
-        entrieslist -- list containing lists of tuples, each tuple contains a coefficient and a column index
+        entrieslist -- a list of lists, where the i-th inner list contains tuples (j, k) such that A[q][j] = k,
+        where A is the constraint matrix, q is the index of the i-th new row, and k is a nonzero entry.
         lhss        -- left-hand side of the row (default 0.0)
         rhss        -- right-hand side of the row (default infinity)
         """


### PR DESCRIPTION
Minor documentation suggestion
- Added in "build from source" documentation (build.rst) that DYLD_LIBRARY_PATH should be set on MacOS to ensure that PySCIPOPT can find scip dynamic library during runtime
- Clarified the formatting of entries and entries list for functions addRow, addRows, addCol, and addCols in the LP interface