### PR TITLE
Release 5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 ### Added
+### Fixed
+### Changed
+### Removed
+
+## 5.6.0 - 2025.XX.YY
+### Added
 - More support for AND-Constraints
 - Added support for knapsack constraints
 - Added isPositive(), isNegative(), isFeasLE(), isFeasLT(), isFeasGE(), isFeasGT(), isHugeValue(), and tests


### PR DESCRIPTION
fix #971 
fix #1050 
fix #1018 

Just leaving this here for the release we'll probably do next week or the one after. It's going to use SCIP with the following hash: [scip@747acc1e](https://github.com/scipopt/scip/commit/747acc1eddb76397842619f0a30f96692315d50d)
This commit in particular splits stage checks from debug mode, and will be enabled by default on PySCIPOpt. Performance degradation is minimal, and it solves a bunch of user-issues. We'll also add the option to remove these stage checks, for the small performance gain.

Plus, the plan is to also start shipping PySCIPOpt with PaPILO and try to make it compatible with Linux ARM.