### PR TITLE
Add changelog entry for new stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 ### Added
+- Added basic type stubs to help with IDE autocompletion and type checking.
 ### Fixed
+- Fixed the type of @ matrix operation result from MatrixVariable to MatrixExpr.
 ### Changed
 ### Removed
 
@@ -24,7 +26,6 @@
 ### Fixed
 - Raised an error when an expression is used when a variable is required
 - Fixed some compile warnings
-- Fixed the type of @ matrix operation result from MatrixVariable to MatrixExpr.
 ### Changed
 - MatrixExpr.sum() now supports axis arguments and can return either a scalar or MatrixExpr, depending on the result dimensions.
 - AddMatrixCons() also accepts ExprCons.


### PR DESCRIPTION
As requested in #1073.

Also, the changelog in #1059 was added to the v5.6.0 release instead of the unreleased section, so I fixed that.