### PR TITLE
TST: test `matrix.sum` costing time

### DIFF
--- a/tests/test_matrix_variable.py
+++ b/tests/test_matrix_variable.py
@@ -217,7 +217,7 @@ def test_matrix_sum_argument():
     assert (m.getVal(y) == np.full((2, 4), 3)).all().all()
 
 
-@pytest.mark.parametrize("n", [100, 200, 500])
+@pytest.mark.parametrize("n", [50, 100, 200])
 def test_sum_performance(n):
     model = Model()
     x = model.addMatrixVar((n, n))


### PR DESCRIPTION
> Yeah, it seems like the tests are not passing, I'm gonna skip the test. Are you sure this is faster?

My bad, I should use `np.ndarray.sum` instead of `np.sum`.
`np.sum` is still using the subclass sum method.

```python
import numpy as np


def quicksum(a: np.ndarray):
    res = 0
    for i in a.flat:
        res += i
    return res


class Matrix(np.ndarray):
    def sum(self, *args, **kwargs):
        if kwargs.get("axis") is None:   
            print("sum via quicksum")
            return quicksum(self)
        else:
            print("sum via np.sum")
            return super().sum(*args, **kwargs)

m = Matrix((2, 2))
m.flat = [[1, 1], [1, 1]]
print(m.sum())
print("----")
print(np.ndarray.sum(m))
print("-----")
print(np.sum(m))
```
Output:

```
sum via quicksum
4.0
----
4.0
-----
sum via quicksum
4.0
```

_Originally posted by @Zeroto521 in https://github.com/scipopt/PySCIPOpt/issues/1078#issuecomment-3424336287_
            