### PR TITLE
Allow to run integration tests on-demand

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'master'
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
The trigger must be present in the `master` branch before it can be used.

See https://github.com/scipopt/PySCIPOpt/pull/1094#issuecomment-3456727023

