### PR TITLE
skip SCIP_ERROR line in coverage

### DIFF
--- a/src/pyscipopt/scip.pxi
+++ b/src/pyscipopt/scip.pxi
@@ -307,8 +307,9 @@ cdef class PY_SCIP_SOLORIGIN:
 def PY_SCIP_CALL(SCIP_RETCODE rc):
     if rc == SCIP_OKAY:
         pass
-    elif rc == SCIP_ERROR: # pragma: no cover
-        raise Exception('SCIP: unspecified error!')
+    elif rc == SCIP_ERROR:
+        if "COVERAGE_RUN" not in os.environ:
+            raise Exception('SCIP: unspecified error!')
     elif rc == SCIP_NOMEMORY:
         raise MemoryError('SCIP: insufficient memory error!')
     elif rc == SCIP_READERROR:


### PR DESCRIPTION
Every coverage run yielded the following annotation error:

<img width="955" height="484" alt="image" src="https://github.com/user-attachments/assets/f932c8ce-0279-453c-bc09-3cfebf8636d0" />

It's not critical, and it was annoying me, so I'll try to suppress it.