### PR TITLE
Check Existence of lib when building using custom scip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,13 @@ else:
         libname = "scip"
     else:
         # assume that SCIP is installed on the system
-        libdir = os.path.abspath(os.path.join(scipoptdir, "lib"))
+        # check for lib64 first (newer SCIP tarballs), then lib
+        if os.path.exists(os.path.join(scipoptdir, "lib64")):
+            libdir = os.path.abspath(os.path.join(scipoptdir, "lib64"))
+        elif os.path.exists(os.path.join(scipoptdir, "lib")):
+            libdir = os.path.abspath(os.path.join(scipoptdir, "lib"))
+        else:
+            sys.exit("Could not find lib or lib64 directory in SCIPOPTDIR=%s" % scipoptdir)
         libname = "libscip" if platform.system() == "Windows" else "scip"
 
     print("Using include path %s." % includedirs)


### PR DESCRIPTION
Hello,

In the new SCIP 10 tarball the lib folder was named lib64 rather than lib. Hence an adjustment was made to check which folder (lib or lib64 exist). 

Cheers,
Gen