### PR TITLE
Increase minimum numpy version to 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 - changed default value of enablepricing flag to True
 - Speed up np.ndarray(..., dtype=np.float64) @ MatrixExpr
+- Minimum numpy version increased from 1.16.0 to 1.19.0
 ### Removed
 
 ## 6.0.0 - 2025.xx.yy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python interface and modeling environment for SCIP"
 authors = [
     {name = "Zuse Institute Berlin", email = "scip@zib.de"},
 ]
-dependencies = ['numpy >=1.16.0']
+dependencies = ['numpy >=1.19.0']
 requires-python = ">=3.8"
 readme = "README.md"
 license = {text = "MIT License"}


### PR DESCRIPTION
This version is more than 5 years old. This is to fix the pipelines (see [here](https://github.com/scipopt/PySCIPOpt/actions/runs/21166587645/job/60872716366)), following #1159