### PR TITLE
Remove outdated warning about Makefile build system incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed `Py_INCREF`/`Py_DECREF` on `Model` in `catchEvent`/`dropEvent` that caused memory leak for imbalanced usage
 ### Changed
 ### Removed
+- Removed outdated warning about Make build system incompatibility
 
 ## 6.1.0 - 2026.01.31
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,10 +18,6 @@ Suite](https://www.scipopt.org/). Please, make sure that your SCIP installation 
 
 **Note that the latest PySCIPOpt version is usually only compatible with the latest major release of the SCIP Optimization Suite. See the table on the README.md page for details.**
 
-If you install SCIP yourself and are not using the installer packages, you need to [install the
-SCIP Optimization Suite using CMake](https://www.scipopt.org/doc/html/md_INSTALL.php#CMAKE).
-The Makefile system is not compatible with PySCIPOpt!
-
 If installing SCIP from source or using PyPI with a python and operating system that is not mentioned above, and SCIP is not installed in the global path,
 you need to specify the install location using the environment variable
 `SCIPOPTDIR`:

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -44,10 +44,6 @@ To download SCIP please either use the pre-built SCIP Optimization Suite availab
     * - 3.2
       - 1.0
 
-.. note:: If you install SCIP yourself and are not using the pre-built packages,
-  you need to install the SCIP Optimization Suite using CMake.
-  The Makefile system is not compatible with PySCIPOpt!
-
 Download Source Code
 ======================
 


### PR DESCRIPTION
Marc can work with PySCIPOpt using a SCIP built with Makefiles, rather than CMake. He fixed a name clash on SCIP that only affected Makefiles, but it may be that prior fixes also contributed to this now working. I confess it's a bit cryptic to me.