### PR TITLE
Avoid random order dependence of nonlinear expressions

### DIFF
--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -108,7 +108,7 @@ cdef class Term:
     cdef Py_ssize_t hashval
 
     def __init__(self, *vartuple: Variable):
-        self.vartuple = tuple(sorted(vartuple, key=lambda v: v.ptr()))
+        self.vartuple = tuple(sorted(vartuple, key=lambda v: v.getIndex()))
         self.ptrtuple = tuple(v.ptr() for v in self.vartuple)
         self.hashval = <Py_ssize_t>hash(self.ptrtuple)
 
@@ -138,7 +138,7 @@ cdef class Term:
         while i < n1 and j < n2:
             var1 = <Variable>PyTuple_GET_ITEM(self.vartuple, i)
             var2 = <Variable>PyTuple_GET_ITEM(other.vartuple, j)
-            if var1.ptr() <= var2.ptr():
+            if var1.getIndex() <= var2.getIndex():
                 vartuple[k] = var1
                 i += 1
             else:


### PR DESCRIPTION
Parsing the terms in a nonlinear expression sorts the terms according to the pointer of the SCIP variable. This causes random effects, since the pointer varies from run to run. In particular, the solving times vary significantly from instance to instance.

This MR uses `getIndex()` instead of `ptr()`. This seems to fix the issue.

However, I am not sure whether there are other cases in which the order depends on such effects.