### PR TITLE
Upgrade to SCIP 10.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 ### Added
+### Fixed
+### Changed
+### Removed
+
+## 6.2.0 - 2026.04.23
+### Added
 - `Expr` and `GenExpr` support NumPy unary functions (`np.sin`, `np.cos`, `np.sqrt`, `np.exp`, `np.log`, `np.absolute`, `np.negative`)
 - `Expr` and `GenExpr` support NumPy binary functions (`np.add`, `np.subtract`, `np.multiply`, `np.divide`, `np.true_divide`, `np.power`, `np.less_equal`, `np.greater_equal`, `np.equal`)
 - Added `getBase()` and `setBase()` methods to `LP` class for getting/setting basis status

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 Requirements
 ============
 
-From version 5.0.0 SCIP is automatically shipped when using PyPI for the following systems:
+From version 5.0.0, SCIP is automatically shipped when using PyPI for the following systems:
 
 - CPython 3.8 / 3.9 / 3.10 / 3.11 / 3.12 for  Linux (manylinux2014)
 - CPython 3.8 / 3.9 / 3.10 / 3.11 / 3.12 for MacOS for x86_64 / ARM64
@@ -16,7 +16,7 @@ When installing from source or using PyPI with a python version and operating sy
 PySCIPOpt requires a working installation of the [SCIP Optimization
 Suite](https://www.scipopt.org/). Please, make sure that your SCIP installation works!
 
-**Note that the latest PySCIPOpt version is usually only compatible with the latest major release of the SCIP Optimization Suite. See the table on the README.md page for details.**
+**Note that the latest PySCIPOpt version is usually only compatible with the latest major release of the SCIP Optimization Suite. See the [online documentation](https://pyscipopt.readthedocs.io/en/latest/build.html#building-from-source) for details.**
 
 If installing SCIP from source or using PyPI with a python and operating system that is not mentioned above, and SCIP is not installed in the global path,
 you need to specify the install location using the environment variable

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -21,6 +21,8 @@ To download SCIP please either use the pre-built SCIP Optimization Suite availab
 
     * - SCIP
       - PySCIPOpt
+    * - 10.0.2
+      - 6.2  
     * - 10.0.1
       - 6.1
     * - 10.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,9 @@ AARCH=$(uname -m)
 echo "------"
 echo $AARCH
 if [[ $AARCH == "aarch64" ]]; then
-    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.11.0/libscip-linux-arm.zip -O scip.zip
+    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-linux-arm.zip -O scip.zip
 else
-    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.11.0/libscip-linux.zip -O scip.zip
+    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-linux.zip -O scip.zip
 fi
 unzip scip.zip
 mv scip_install scip
@@ -65,10 +65,10 @@ before-all = '''
 #!/bin/bash
 brew install wget zlib gcc
 if [[ $CIBW_ARCHS == *"arm"* ]]; then
-    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.11.0/libscip-macos-arm.zip -O scip.zip
+    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-macos-arm.zip -O scip.zip
     export MACOSX_DEPLOYMENT_TARGET=14.0
 else
-    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.11.0/libscip-macos-intel.zip -O scip.zip
+    wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-macos-intel.zip -O scip.zip
     export MACOSX_DEPLOYMENT_TARGET=14.0
 fi
 unzip scip.zip
@@ -94,7 +94,7 @@ repair-wheel-command = '''
 skip="pp* cp36* cp37*"
 before-all = [
     "choco install 7zip wget",
-    "wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.11.0/libscip-windows.zip -O scip.zip",
+    "wget https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-windows.zip -O scip.zip",
     "\"C:\\Program Files\\7-Zip\\7z.exe\" x \"scip.zip\" -o\"scip-test\"",
     "mv .\\scip-test\\scip_install .\\test",
     "mv .\\test .\\scip"

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ with open("README.md") as f:
 
 setup(
     name="PySCIPOpt",
-    version="6.1.0",
+    version="6.2.0",
     description="Python interface and modeling environment for SCIP",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/pyscipopt/_version.py
+++ b/src/pyscipopt/_version.py
@@ -1,1 +1,1 @@
-__version__: str = '6.1.0'
+__version__: str = '6.2.0'


### PR DESCRIPTION
Updates scipoptsuite-deploy v0.11.0 -> v0.12.0 (SCIP 10.0.2, SoPlex 8.0.2, GCG 4.0.2, IPOPT 3.14.19).

## Checklist
- [x] Fix any API incompatibilities
- [x] CI is green
- [x] Update [compatibility table](https://pyscipopt.readthedocs.io/en/latest/build.html#building-from-source) if needed
- [x] Merge and run `./release.sh`