### PR TITLE
Make `test_tree` more robust 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed stubtest failures with mypy 1.20 by marking dunder method parameters as positional-only
 - Return `MatrixGenExpr` in `buildGenExprObj` instead of `MatrixExpr`
 - Plugins now hold strong references to their `Model` instead of `weakref.proxy`, fixing `ReferenceError` during cleanup callbacks (#1193)
+- Made `test_tree` robust to SCIP solver improvements by asserting visited node depths instead of node count (#1206)
 ### Changed
 - Return NotImplemented for `Expr` and `GenExpr` operators if they can't handle input types in the calculation
 - Speed up `constant * Expr` via C-level API

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -6,7 +6,7 @@ from pyscipopt import Model, Eventhdlr, SCIP_RESULT, SCIP_EVENTTYPE, SCIP_PARAMS
 class NodeEventHandler(Eventhdlr):
 
     def __init__(self):
-        self.calls = []
+        self.depths_seen = set()
 
     def eventinit(self):
         self.model.catchEvent(SCIP_EVENTTYPE.NODEFOCUSED, self)
@@ -15,10 +15,10 @@ class NodeEventHandler(Eventhdlr):
         self.model.dropEvent(SCIP_EVENTTYPE.NODEFOCUSED, self)
 
     def eventexec(self, event):
-        self.calls.append('eventexec')
         assert event.getType() == SCIP_EVENTTYPE.NODEFOCUSED
         node = event.getNode()
-        
+        self.depths_seen.add(node.getDepth())
+
         if node.getDepth() == 0:
             assert node.getParent() is None
             assert node.getParentBranchings() is None
@@ -39,6 +39,8 @@ def test_tree():
     s.setMaximize()
     s.hideOutput()
     s.setPresolve(SCIP_PARAMSETTING.OFF)
+    s.setSeparating(SCIP_PARAMSETTING.OFF)
+    s.setHeuristics(SCIP_PARAMSETTING.OFF)
     node_eventhdlr = NodeEventHandler()
     s.includeEventhdlr(node_eventhdlr, "NodeEventHandler", "python event handler to catch NODEFOCUSED")
 
@@ -60,4 +62,5 @@ def test_tree():
 
     del s
 
-    assert len(node_eventhdlr.calls) > 3
+    assert 0 in node_eventhdlr.depths_seen
+    assert any(d > 0 for d in node_eventhdlr.depths_seen)


### PR DESCRIPTION
Previous assertion assumed too much. Should be the cause behind #1206, will close it if the new release indeed fixes it.