### PR TITLE
BUG: `Expr.__array_ufunc__` can't handle 0-dim array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 ### Fixed
+- `Expr.__array_ufunc__` can't handle 0-dim array
 ### Changed
 ### Removed
 

--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -211,7 +211,8 @@ cdef class ExprLike:
                 return ufunc(*[_ensure_matrix(a) for a in args], **kwargs)
 
             # Convert `np.generic` and 0-dim `np.ndarray` to native Python types to stop
-            # __array_ufunc__ recursion from `np.generic + MatrixExpr/Expr`.
+            # __array_ufunc__ recursion from `np.generic + MatrixExpr/Expr` or
+            # `0-dim np.ndarray + MatrixExpr/Expr`.
             args = [
                 a.item()
                 if (

--- a/src/pyscipopt/expr.pxi
+++ b/src/pyscipopt/expr.pxi
@@ -203,16 +203,24 @@ cdef class ExprLike:
             )
 
         if method == "__call__":
-            if arrays := [a for a in args if isinstance(a, np.ndarray)]:
+            if arrays := [a for a in args if isinstance(a, np.ndarray) and a.ndim >= 1]:
                 if any(a.dtype.kind not in "fiub" for a in arrays):
                     return NotImplemented
                 # If the np.ndarray is of numeric type, all arguments are converted to
                 # MatrixExpr or MatrixGenExpr and then the ufunc is applied.
                 return ufunc(*[_ensure_matrix(a) for a in args], **kwargs)
 
-            # Convert `np.generic` to native Python types to stop __array_ufunc__
-            # recursion from `np.generic + MatrixExpr`.
-            args = [a.item() if isinstance(a, np.generic) else a for a in args]
+            # Convert `np.generic` and 0-dim `np.ndarray` to native Python types to stop
+            # __array_ufunc__ recursion from `np.generic + MatrixExpr/Expr`.
+            args = [
+                a.item()
+                if (
+                    isinstance(a, np.generic)
+                    or (isinstance(a, np.ndarray) and a.ndim == 0)
+                )
+                else a
+                for a in args
+            ]
 
             if ufunc is np.add:
                 return args[0] + args[1]

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -328,16 +328,28 @@ def test_binary_ufunc(model):
     assert str(np.greater_equal(a, x)) == "[ExprCons(Expr({Term(x): 1.0}), None, 2.0)]"
 
 
-def test_np_generic_cmp_with_expr():
+def test_np_generic_vs_expr():
     # test #1218
     m = Model()
     x = m.addVar(name="x")
     value = np.float64(5.0)
 
+    # test <=
     assert str(x <= -value) == "ExprCons(Expr({Term(x): 1.0}), None, -5.0)"
-    assert str(x <= value ) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
+    assert str(x <= value) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
     assert str(-value <= x) == "ExprCons(Expr({Term(x): 1.0}), -5.0, None)"
     assert str(value <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
+    assert str(np.int64(5) <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
+
+    # test >=
+    assert str(value >= x) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
+    assert str(-value >= x) == "ExprCons(Expr({Term(x): 1.0}), None, -5.0)"
+
+    # test ==
+    assert str(value == x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, 5.0)"
+
+    # test 0-ndim array
+    assert str(np.array(5) <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
 
 
 def test_mul():

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -334,21 +334,21 @@ def test_np_generic_vs_expr():
     x = m.addVar(name="x")
     value = np.float64(5.0)
 
-    # test <=
+    # test <=, np.generic vs Variable
     assert str(x <= -value) == "ExprCons(Expr({Term(x): 1.0}), None, -5.0)"
     assert str(x <= value) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
     assert str(-value <= x) == "ExprCons(Expr({Term(x): 1.0}), -5.0, None)"
     assert str(value <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
     assert str(np.int64(5) <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
 
-    # test >=
+    # test >=, np.generic vs Variable
     assert str(value >= x) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
     assert str(-value >= x) == "ExprCons(Expr({Term(x): 1.0}), None, -5.0)"
 
-    # test ==
+    # test ==, np.generic vs Variable
     assert str(value == x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, 5.0)"
 
-    # test 0-ndim array
+    # test <=, 0-ndim int array vs Variable
     assert str(np.array(5) <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
 
 

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -351,6 +351,10 @@ def test_np_generic_vs_expr():
     # test <=, 0-ndim int array vs Variable
     assert str(np.array(5) <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
 
+    # test <=, 0-ndim Variable array vs Variable
+    with pytest.raises(TypeError):
+        1 <= np.array(x)
+
 
 def test_mul():
     m = Model()

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -328,6 +328,18 @@ def test_binary_ufunc(model):
     assert str(np.greater_equal(a, x)) == "[ExprCons(Expr({Term(x): 1.0}), None, 2.0)]"
 
 
+def test_np_generic_cmp_with_expr():
+    # test #1218
+    m = Model()
+    x = m.addVar(name="x")
+    value = np.float64(5.0)
+
+    assert str(x <= -value) == "ExprCons(Expr({Term(x): 1.0}), None, -5.0)"
+    assert str(x <= value ) == "ExprCons(Expr({Term(x): 1.0}), None, 5.0)"
+    assert str(-value <= x) == "ExprCons(Expr({Term(x): 1.0}), -5.0, None)"
+    assert str(value <= x) == "ExprCons(Expr({Term(x): 1.0}), 5.0, None)"
+
+
 def test_mul():
     m = Model()
     x = m.addVar(name="x")


### PR DESCRIPTION
fix #1218

numpy automatically converts `np.generic` to a 0-dim array.

```python
import numpy as np


class Expr:
    def __array_ufunc__(self, ufunc, method, *args, **kwargs):
        print("-" * 50)
        print(args)
        print([type(a) for a in args])
        print("-" * 50)

        return NotImplemented

    def __init__(self, value: int):
        self.value = value

    def __repr__(self):
        return f"Expr({self.value})"

    def __le__(self, other: int):
        return self.value <= other


if __name__ == "__main__":
    x = Expr(5)
    value = np.float64(5.0)
    print(value <= x)

    # --------------------------------------------------
    # (array(5.), Expr(5))  # <-- the first argument is a numpy array, not np.float64
    # [<class 'numpy.ndarray'>, <class '__main__.Expr'>]
    # --------------------------------------------------
```