### PR TITLE
Fix failing structured trace handler reuse test on master

### DIFF
--- a/tests/test_recipe_structured_optimization_trace.py
+++ b/tests/test_recipe_structured_optimization_trace.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from helpers.utils import bin_packing_model
 
+from pyscipopt import SCIP_PARAMSETTING
 from pyscipopt.recipes.structured_optimization_trace import (
     attach_structured_optimization_trace,
     structured_optimization_trace,
@@ -147,7 +148,7 @@ def test_structured_optimization_trace_records_run_end_on_exception():
 
 def test_structured_optimization_trace_reuses_handler_for_repeated_contexts(tmp_path):
     model = _model()
-    model.setParam("limits/time", 1)
+    model.setPresolve(SCIP_PARAMSETTING.OFF)
     first_path = tmp_path / "first.jsonl"
     second_path = tmp_path / "second.jsonl"
 


### PR DESCRIPTION
**Summary**
Fix `test_structured_optimization_trace_reuses_handler_for_repeated_contexts`, which is currently failing on `master`.

On the Windows runner, the one-second time limit could be exhausted during presolving, before any trace event was emitted. This left the trace with only a `run_end` record and caused the test to fail.

This PR:
- disables presolving in the structured trace handler reuse test
- retains the five-second optimization limit configured by `_model()`

**Why this was not caught before merge**
The failure was detected only after merging because the `Integration test` workflow runs on pushes to `master`, but not on pull requests.

**Follow-up**
I propose tracking the pre-merge CI coverage gap in a separate issue, including whether the `Integration test` workflow should run before merge. This PR leaves the CI configuration unchanged and is limited to fixing the failing test.