### PR TITLE
Fix Cython 3.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Expr` and `GenExpr` support `__pos__` magic method like `+Expr` or `+GenExpr`
 - Added type annotations to most methods on the `Model` class
 ### Fixed
+- Fixed Cython 3.3 compatibility (#1248)
 - Made `test_markDoNotAggrVar_and_getStatus` robust to SCIP presolve changes by discovering the aggregated/multi-aggregated variables instead of hardcoding them
 ### Changed
 - Move magic methods (`__radd__`, `__sub__`, `__rsub__`, `__rmul__`, `__richcmp__`, `__neg__`, and `__rtruediv__`) to `ExprLike` base class (#1204)

--- a/src/pyscipopt/matrix.pxi
+++ b/src/pyscipopt/matrix.pxi
@@ -233,10 +233,10 @@ def _core_sum(
         a np.ndarray.
 
     """
-    axis: Tuple[int, ...] = normalize_axis_tuple(
+    axis_tuple: Tuple[int, ...] = normalize_axis_tuple(
         range(a.ndim) if axis is None else axis, a.ndim
     )
-    if len(axis) == a.ndim:
+    if len(axis_tuple) == a.ndim:
         res = quicksum(a.flat)
         return (
             np.array([res], dtype=object).reshape([1] * a.ndim)
@@ -244,12 +244,12 @@ def _core_sum(
             else res
         )
 
-    keep_axes = tuple(i for i in range(a.ndim) if i not in axis)
+    keep_axes = tuple(i for i in range(a.ndim) if i not in axis_tuple)
     shape = (
-        tuple(1 if i in axis else a.shape[i] for i in range(a.ndim))
+        tuple(1 if i in axis_tuple else a.shape[i] for i in range(a.ndim))
         if keepdims
         else tuple(a.shape[i] for i in keep_axes)
     )
     return np.apply_along_axis(
-        quicksum, -1, a.transpose(keep_axes + axis).reshape(shape + (-1,))
+        quicksum, -1, a.transpose(keep_axes + axis_tuple).reshape(shape + (-1,))
     )


### PR DESCRIPTION
Do not redeclare variables with different types. Use new names rather than redeclaring/shadowing the old ones.

Fixes #1247. See also https://github.com/cython/cython/issues/7246.